### PR TITLE
Add Trivy repo scanning to CI

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, development ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ main ]
+    branches: [ main, development ]
   schedule:
     - cron: '32 15 * * 3'
 
@@ -50,22 +50,6 @@ jobs:
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
-
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.github/workflows/trivy-code-analysis.yml
+++ b/.github/workflows/trivy-code-analysis.yml
@@ -29,7 +29,6 @@ jobs:
           format: 'template'
           template: '@/contrib/sarif.tpl'
           output: 'trivy-results.sarif'
-          severity: 'CRITICAL'
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v1

--- a/.github/workflows/trivy-code-analysis.yml
+++ b/.github/workflows/trivy-code-analysis.yml
@@ -1,0 +1,37 @@
+# From: https://github.com/aquasecurity/trivy-action
+name: build
+on:
+  push:
+    branches: [ main, development ]
+  pull_request:
+    branches: [ main, development ]
+  schedule:
+    - cron: '32 15 * * 3'
+
+jobs:
+  analyze:
+    name: Build
+    runs-on: ubuntu-18.04
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Run Trivy vulnerability scanner in repo mode
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'fs'
+          ignore-unfixed: true
+          format: 'template'
+          template: '@/contrib/sarif.tpl'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/trivy-code-analysis.yml
+++ b/.github/workflows/trivy-code-analysis.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   analyze:
-    name: Build
+    name: Analyze
     runs-on: ubuntu-18.04
     permissions:
       actions: read

--- a/.github/workflows/trivy-code-analysis.yml
+++ b/.github/workflows/trivy-code-analysis.yml
@@ -1,5 +1,5 @@
 # From: https://github.com/aquasecurity/trivy-action
-name: build
+name: "Trivy Repo Scan"
 on:
   push:
     branches: [ main, development ]


### PR DESCRIPTION
Add Trivy repo scanning to CI to detect node.js dependency vulnerabilities. We still need to add container checks. However, that will need to wait until we are able to build the containers with GitHub Actions.

Closes #633 