### PR TITLE
Use an unprivileged port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ ENV SCRIPTS_FOLDER=/docker
 ENV APPNAME=${APPNAME}
 ENV SETTINGS_DIR=${APP_FOLDER}/settings/${APPNAME}
 ENV MONGO_URL=mongodb://mongo:27017/${APPNAME}
-ENV PORT=80
+ENV PORT=9000
 ENV ROOT_URL=http://localhost:${PORT}/
 
 # Copy in helper scripts

--- a/container-scripts/run_app.sh
+++ b/container-scripts/run_app.sh
@@ -11,7 +11,7 @@ if [ $DELAY ]; then
 fi
 
 # Honour already existing PORT setup
-export PORT=${PORT:-80}
+export PORT=${PORT:-9000}
 export NODE_ENV=production
 
 # check for persisted meteor settings and if not present create a template

--- a/scripts/common/mats_build_deploy_apps_parallel.sh
+++ b/scripts/common/mats_build_deploy_apps_parallel.sh
@@ -429,8 +429,8 @@ RUN apk --update --no-cache add mongodb-tools make g++ python3 py3-pip py3-numpy
 			/root/.node-gyp \\
 			/root/.cache
 ENV MONGO_URL=mongodb://mongo:27017/${APPNAME}
-ENV ROOT_URL=http://localhost:80/
-EXPOSE 80
+ENV ROOT_URL=http://localhost:9000/
+EXPOSE 9000
 RUN chown -R node:node /usr/app
 USER node
 ENTRYPOINT ["/usr/app/run_app.sh"]


### PR DESCRIPTION
This change exposes the meteor app in the container on port 9000 instead of port 80. We can no longer bind to port 80 on Linux now that we're running as a non-root user.

Closes #649 