### PR TITLE
Don't prune development images

### DIFF
--- a/.github/workflows/prune-pr-images.yml
+++ b/.github/workflows/prune-pr-images.yml
@@ -40,6 +40,7 @@ jobs:
           echo "BRANCH=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
           echo "APP_LOWERCASE=${APP,,}" >> $GITHUB_ENV
       - name: Cleanup images
+        if: ${{ env.BRANCH }} != "development" # don't prune images from the development branch
         uses: bots-house/ghcr-delete-image-action@v1.0.1
         with:
           owner: noaa-gsl


### PR DESCRIPTION
The action to prune container images after a PR is closed will prune images associated with the development branch if we create a PR from there to another branch. (E.g. - main) This is undesirable. 

Closes #653 