### PR TITLE
Reduce our job timeout from 6 hours to 20 min

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: true
       matrix:


### PR DESCRIPTION
GitHub support recommends we decrease our job timeout to speed up feedback on stuck builds. Our jobs should only take 10 minutes so 20 minutes seems reasonable.

Closes #658 