### PR TITLE
Create stage for container debugging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -104,3 +104,12 @@ CMD ["node", "main.js"]
 
 # Add Labels
 LABEL version=${BUILDVER} code.branch=${COMMITBRANCH} code.commit=${COMMITSHA}
+
+
+# Create a stage with the root user for debugging
+# Note - you'll need to override the entrypoint if you want a shell (docker run --entrypoint /bin/bash ...)
+FROM production AS debug
+USER root
+
+# Use the production stage by default
+FROM production

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,10 +27,10 @@ ENV SCRIPTS_FOLDER /docker
 
 # Install OS build dependencies, which stay with this intermediate image but don’t become part of the final published image
 RUN apk --no-cache add \
-	bash \
-	g++ \
-	make \
-	python3
+    bash \
+    g++ \
+    make \
+    python3
 
 # Copy in entrypoint
 COPY --from=meteor-builder $SCRIPTS_FOLDER $SCRIPTS_FOLDER/
@@ -42,7 +42,7 @@ RUN bash $SCRIPTS_FOLDER/build-meteor-npm-dependencies.sh --build-from-source
 
 
 # Use the specific version of Node expected by your Meteor release, per https://docs.meteor.com/changelog.html
-FROM node:14.18-alpine3.15
+FROM node:14.18-alpine3.15 AS production
 
 # Set Build ARGS
 ARG APPNAME
@@ -52,13 +52,13 @@ ARG COMMITSHA
 
 # Install runtime dependencies
 RUN apk --no-cache add \
-                    bash \
-                    ca-certificates \
-                    mariadb \
-                    mongodb-tools \
-                    python3 \
-                    py3-numpy \
-                    py3-pip \
+    bash \
+    ca-certificates \
+    mariadb \
+    mongodb-tools \
+    python3 \
+    py3-numpy \
+    py3-pip \
     && pip3 --no-cache-dir install pymysql
 
 # Set Environment


### PR DESCRIPTION
Add a `debug` stage that can be targeted with `docker build --target debug ...` to make debugging easier.

Closes #682 