### PR TITLE
Use the latest version of Trivy in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
             .
 
       - name: Scan container with Trivy
-        uses: aquasecurity/trivy-action@0.0.20
+        uses: aquasecurity/trivy-action@master
         with:
           image-ref: '${{ env.REGISTRY }}/${{ env.APP_LOWERCASE }}:${{ env.BRANCH }}'
           format: 'template'


### PR DESCRIPTION
Trivy was pinned to 0.0.20 which wasn't compatible with alpine 3.15 and
was silently failing.