### PR TITLE
Support the couchbase SDK in docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,7 @@ RELEASE.txt
 appProduction*
 bundle*
 node_modules
+.npm
 cache*
 container_deployment
 home


### PR DESCRIPTION
Force a rebuild of the mats-common dependencies

The mats-common Meteor Atmosphere package installs some native
dependencies in the first stage of this Dockerfile. That stage uses a
Ubuntu base image so causes problems when we switch to the
musl-based Alpine production image. We need to 'npm rebuild' in the
meteor package's node_modules as well as the places the
'build-meteor-npm-dependencies.sh' script does it.

Closes #689 