### PR TITLE
Fix the syntax for .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,8 +5,8 @@ README*
 RELEASE.txt
 appProduction*
 bundle*
-node_modules
-.npm
+**/node_modules
+**/.npm
 cache*
 container_deployment
 home


### PR DESCRIPTION
.dockerignore files follow Go's filepath.Match rules which is not
similar to how .gitignore files work. We need to use the ** glob
expansion to match subdirectories.