### PR TITLE
Fix untagged image cleanup

### DIFF
--- a/.github/workflows/prune-untagged-images.yml
+++ b/.github/workflows/prune-untagged-images.yml
@@ -30,7 +30,7 @@ jobs:
           - upperair
     steps:
       - name: Delete image
-        uses: snok/container-retention-policy@v1.1.0
+        uses: snok/container-retention-policy@v1.4.1
         with:
           image-names: mats/development/${{ matrix.app }}
           cut-off: 1 day ago MST


### PR DESCRIPTION
The upstream GH Action had an unpinned dependency change and broke the action. This was fixed in 1.4.1 by pinning their dependencies. https://github.com/snok/container-retention-policy/releases/tag/v1.4.1