### PR TITLE
Fix deploy action syntax

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,13 +45,13 @@ jobs:
 
       - name: Pull image
         run: |
-          docker pull ${{ env.DEV_REGISTRY }}/${{ env.APP_NAME }}:${ GITHUB_REF }
+          docker pull ${{ env.DEV_REGISTRY }}/${{ env.APP_NAME }}:${GITHUB_REF#refs/tags/}
 
       - name: Retag image
         run: |
-          docker tag ${{ env.DEV_REGISTRY }}/${{ env.APP_NAME }}:${ GITHUB_REF } \
-                     ${{ env.PROD_REGISTRY }}/${{ env.APP_NAME }}:${ GITHUB_REF }
+          docker tag ${{ env.DEV_REGISTRY }}/${{ env.APP_NAME }}:${GITHUB_REF#refs/tags/} \
+                     ${{ env.PROD_REGISTRY }}/${{ env.APP_NAME }}:${GITHUB_REF#refs/tags/}
 
       - name: Push image
         run: |
-          docker push ${{ env.PROD_REGISTRY }}/${{ env.APP_NAME }}:${ GITHUB_REF }
+          docker push ${{ env.PROD_REGISTRY }}/${{ env.APP_NAME }}:${GITHUB_REF#refs/tags/}


### PR DESCRIPTION
Whitespace isn't valid in an `${ENV}` block. Also, remove the leading `refs/tags/` as we don't want that in our image tags.

This was tested in a sandbox repo here: https://github.com/ian-noaa/github-actions-playground/runs/5879432800?check_suite_focus=true with the following GitHub Actions file: https://github.com/ian-noaa/github-actions-playground/blob/dc29529916f73937d33e562097801f79eb7522ab/.github/workflows/test-syntax.yml

The results from the test show that the whitespace was the issue and that using syntax like: `${GITHUB_REF:/refs/tags/}` is valid and will trim the extra parts of the ref we don't want in our image tags.