### PR TITLE
Add a CI job to label stale issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,15 @@
+name: 'Label stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 2 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v6
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 90 days with no activity.'
+          stale-pr-message: 'This PR is stale because it has been open 90 days with no activity.'
+          days-before-stale: 90
+          days-before-close: -1


### PR DESCRIPTION
The team wanted issues and PRs to be marked as stale after 90 days and didn't want issues or PRs to be automatically closed.

Closes #832 