### PR TITLE
Turn on dependabot for GHA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,5 +9,5 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-   pull-request-branch-name:
+    pull-request-branch-name:
       seperator: "-" # Use "-" instead of "/" in branch names to avoid issues with docker registries

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,4 +10,4 @@ updates:
     schedule:
       interval: "weekly"
     pull-request-branch-name:
-      seperator: "-" # Use "-" instead of "/" in branch names to avoid issues with docker registries
+      separator: "-" # Use "-" instead of "/" in branch names to avoid issues with docker registries

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+   pull-request-branch-name:
+      seperator: "-" # Use "-" instead of "/" in branch names to avoid issues with docker registries


### PR DESCRIPTION
Currently, only use [Dependabot on GitHub Actions (GHA)](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot). If we want, we can turn Dependabot on for npm in the future.