### PR TITLE
Turn on dependabot for GitHub Actions (#853)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    pull-request-branch-name:
+      separator: "-" # Use "-" instead of "/" in branch names to avoid issues with docker registries


### PR DESCRIPTION
Currently, only use Dependabot on GitHub Actions (GHA). If we want, we can turn Dependabot on for npm in the future.