### PR TITLE
Dependabot fixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,4 @@ updates:
       interval: "weekly"
     pull-request-branch-name:
       separator: "-" # Use "-" instead of "/" in branch names to avoid issues with docker registries
+    target-branch: "development" # raise PRs for version updates to GHA against the `development` branch

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      packages: write
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,8 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     timeout-minutes: 20
     strategy:
       fail-fast: true


### PR DESCRIPTION
These changes give dependabot permissions to push container images to our registries and switches dependabot to open PRs against the `development` branch. 