### PR TITLE
K8s PR 3 - Deploy the rest of the MATS apps

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -17,6 +17,8 @@ MONGO_INITDB_ROOT_PASSWORD=<admin_password>
 MONGO_INITDB_ROOT_USERNAME=<admin_user>
 ```
 
+And then for each MATS app, you'll need 2 files - a `.env` and a `settings.json`. I'll use the scorecard app as an example:
+
 * A `kubernetes/overlays/local/scorecard/.env` file containing the Delay, Root URL, and Mongo URL:
 
 ```env
@@ -29,7 +31,7 @@ MONGO_URL=mongodb://<admin_user>:<admin_password>@mongodb:27017/scorecard?authSo
 
 You will also need to authenticate your docker client with the container registry. [GitHub has documentation on how to do that with a PAT](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic). Your token will only need `read:packages` permissions and you'll need to authenticate it with the GitHub organization via SSO.
 
-Once you have those three files in place and you're authenticated with the registry, you can start the app with:
+Once you have those settings files in place and you're authenticated with the container registry, you can start the app with:
 
 ```console
 kubectl apply -k kubernetes/overlays/local                # Apply the Kustomize templates for the local services
@@ -37,7 +39,7 @@ kubectl get -k kubernetes/overlays/local                  # Get resource info
 kubectl delete -k kubernetes/overlays/local               # Delete the resources
 ```
 
-You should be able to visit the scorecard app at: http://mats.127.0.0.1.nip.io/scorecard
+You should be able to visit the apps at: `http://mats.127.0.0.1.nip.io/<app_name>`. So for example, the scorecard app would be at: http://mats.127.0.0.1.nip.io/scorecard.
 
 ### Security scanning
 
@@ -98,4 +100,4 @@ In GSL, we will need to add a secret to the intended namespace so we can pull fr
  --docker-password=<PAT with read:packages permission and granted SSO access to the GSL GitHub org>
 ```
 
-For now, you'll need to create appropriate `settings.json` files and `.env` files in each MATS application's configuration which is a pain. They contain secrets so can't be checked into a public git repo. We could investigate sealed secrets or Hashicorp's vault but they would require ITS's buy-in. We also could look to generate them before we `kubectl -n <namespace> apply -k ...` so they're pre-populated in the namespace - similarly to how the docker registry secret is currently handled.
+For now, you'll need to create appropriate `settings.json` files and `.env` files in each MATS application's configuration which is a pain. They contain secrets so can't be checked into a public git repo. We could investigate sealed secrets or Hashicorp's vault but they would require buy-in from IT. We also could look to generate them before we `kubectl -n <namespace> apply -k ...` so they're pre-populated in the namespace - similarly to how the docker registry secret is currently handled.

--- a/kubernetes/base/anomalycor/deployment.yaml
+++ b/kubernetes/base/anomalycor/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: anomalycor
+  labels:
+    app.kubernetes.io/name: anomalycor
+    app.kubernetes.io/part-of: mats
+    app.kubernetes.io/component: frontend
+    app: anomalycor
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: anomalycor
+  template:
+    metadata:
+      labels:
+        app: anomalycor
+    spec:
+      containers:
+        - name: anomalycor
+          image: ghcr.io/noaa-gsl/mats/development/anomalycor:development
+          ports:
+            - containerPort: 9000
+          securityContext:
+            allowPrivilegeEscalation: false
+

--- a/kubernetes/base/anomalycor/kustomization.yaml
+++ b/kubernetes/base/anomalycor/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/kubernetes/base/anomalycor/service.yaml
+++ b/kubernetes/base/anomalycor/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: anomalycor
+  labels:
+    app: anomalycor
+spec:
+  selector:
+    app: anomalycor
+  ports:
+  - port: 80
+    targetPort: 9000
+    protocol: TCP
+    name: http
+  type: ClusterIP

--- a/kubernetes/base/cb-ceiling/deployment.yaml
+++ b/kubernetes/base/cb-ceiling/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cb-ceiling
+  labels:
+    app.kubernetes.io/name: cb-ceiling
+    app.kubernetes.io/part-of: mats
+    app.kubernetes.io/component: frontend
+    app: cb-ceiling
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cb-ceiling
+  template:
+    metadata:
+      labels:
+        app: cb-ceiling
+    spec:
+      containers:
+        - name: cb-ceiling
+          image: ghcr.io/noaa-gsl/mats/development/cb-ceiling:development
+          ports:
+            - containerPort: 9000
+          securityContext:
+            allowPrivilegeEscalation: false
+

--- a/kubernetes/base/cb-ceiling/kustomization.yaml
+++ b/kubernetes/base/cb-ceiling/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/kubernetes/base/cb-ceiling/service.yaml
+++ b/kubernetes/base/cb-ceiling/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cb-ceiling
+  labels:
+    app: cb-ceiling
+spec:
+  selector:
+    app: cb-ceiling
+  ports:
+  - port: 80
+    targetPort: 9000
+    protocol: TCP
+    name: http
+  type: ClusterIP

--- a/kubernetes/base/ceil-vis/deployment.yaml
+++ b/kubernetes/base/ceil-vis/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ceil-vis
+  labels:
+    app.kubernetes.io/name: ceil-vis
+    app.kubernetes.io/part-of: mats
+    app.kubernetes.io/component: frontend
+    app: ceil-vis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ceil-vis
+  template:
+    metadata:
+      labels:
+        app: ceil-vis
+    spec:
+      containers:
+        - name: ceil-vis
+          image: ghcr.io/noaa-gsl/mats/development/ceil-vis:development
+          ports:
+            - containerPort: 9000
+          securityContext:
+            allowPrivilegeEscalation: false
+

--- a/kubernetes/base/ceil-vis/kustomization.yaml
+++ b/kubernetes/base/ceil-vis/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/kubernetes/base/ceil-vis/service.yaml
+++ b/kubernetes/base/ceil-vis/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ceil-vis
+  labels:
+    app: ceil-vis
+spec:
+  selector:
+    app: ceil-vis
+  ports:
+  - port: 80
+    targetPort: 9000
+    protocol: TCP
+    name: http
+  type: ClusterIP

--- a/kubernetes/base/ceil-vis15/deployment.yaml
+++ b/kubernetes/base/ceil-vis15/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ceil-vis15
+  labels:
+    app.kubernetes.io/name: ceil-vis15
+    app.kubernetes.io/part-of: mats
+    app.kubernetes.io/component: frontend
+    app: ceil-vis15
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ceil-vis15
+  template:
+    metadata:
+      labels:
+        app: ceil-vis15
+    spec:
+      containers:
+        - name: ceil-vis15
+          image: ghcr.io/noaa-gsl/mats/development/ceil-vis15:development
+          ports:
+            - containerPort: 9000
+          securityContext:
+            allowPrivilegeEscalation: false
+

--- a/kubernetes/base/ceil-vis15/kustomization.yaml
+++ b/kubernetes/base/ceil-vis15/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/kubernetes/base/ceil-vis15/service.yaml
+++ b/kubernetes/base/ceil-vis15/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ceil-vis15
+  labels:
+    app: ceil-vis15
+spec:
+  selector:
+    app: ceil-vis15
+  ports:
+  - port: 80
+    targetPort: 9000
+    protocol: TCP
+    name: http
+  type: ClusterIP

--- a/kubernetes/base/landuse/deployment.yaml
+++ b/kubernetes/base/landuse/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: landuse
+  labels:
+    app.kubernetes.io/name: landuse
+    app.kubernetes.io/part-of: mats
+    app.kubernetes.io/component: frontend
+    app: landuse
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: landuse
+  template:
+    metadata:
+      labels:
+        app: landuse
+    spec:
+      containers:
+        - name: landuse
+          image: ghcr.io/noaa-gsl/mats/development/landuse:development
+          ports:
+            - containerPort: 9000
+          securityContext:
+            allowPrivilegeEscalation: false
+

--- a/kubernetes/base/landuse/kustomization.yaml
+++ b/kubernetes/base/landuse/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/kubernetes/base/landuse/service.yaml
+++ b/kubernetes/base/landuse/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: landuse
+  labels:
+    app: landuse
+spec:
+  selector:
+    app: landuse
+  ports:
+  - port: 80
+    targetPort: 9000
+    protocol: TCP
+    name: http
+  type: ClusterIP

--- a/kubernetes/base/mongo/pvc.yaml
+++ b/kubernetes/base/mongo/pvc.yaml
@@ -9,4 +9,4 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 1Gi
+      storage: 10Gi

--- a/kubernetes/base/precipAccum/deployment.yaml
+++ b/kubernetes/base/precipAccum/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: precipaccum
+  labels:
+    app.kubernetes.io/name: precipaccum
+    app.kubernetes.io/part-of: mats
+    app.kubernetes.io/component: frontend
+    app: precipaccum
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: precipaccum
+  template:
+    metadata:
+      labels:
+        app: precipaccum
+    spec:
+      containers:
+        - name: precipaccum
+          image: ghcr.io/noaa-gsl/mats/development/precipaccum:development
+          ports:
+            - containerPort: 9000
+          securityContext:
+            allowPrivilegeEscalation: false
+

--- a/kubernetes/base/precipAccum/kustomization.yaml
+++ b/kubernetes/base/precipAccum/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/kubernetes/base/precipAccum/service.yaml
+++ b/kubernetes/base/precipAccum/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: precipaccum
+  labels:
+    app: precipaccum
+spec:
+  selector:
+    app: precipaccum
+  ports:
+  - port: 80
+    targetPort: 9000
+    protocol: TCP
+    name: http
+  type: ClusterIP

--- a/kubernetes/base/precipGauge/deployment.yaml
+++ b/kubernetes/base/precipGauge/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: precipgauge
+  labels:
+    app.kubernetes.io/name: precipgauge
+    app.kubernetes.io/part-of: mats
+    app.kubernetes.io/component: frontend
+    app: precipgauge
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: precipgauge
+  template:
+    metadata:
+      labels:
+        app: precipgauge
+    spec:
+      containers:
+        - name: precipgauge
+          image: ghcr.io/noaa-gsl/mats/development/precipgauge:development
+          ports:
+            - containerPort: 9000
+          securityContext:
+            allowPrivilegeEscalation: false
+

--- a/kubernetes/base/precipGauge/kustomization.yaml
+++ b/kubernetes/base/precipGauge/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/kubernetes/base/precipGauge/service.yaml
+++ b/kubernetes/base/precipGauge/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: precipgauge
+  labels:
+    app: precipgauge
+spec:
+  selector:
+    app: precipgauge
+  ports:
+  - port: 80
+    targetPort: 9000
+    protocol: TCP
+    name: http
+  type: ClusterIP

--- a/kubernetes/base/precipitation1hr/deployment.yaml
+++ b/kubernetes/base/precipitation1hr/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: precipitation1hr
+  labels:
+    app.kubernetes.io/name: precipitation1hr
+    app.kubernetes.io/part-of: mats
+    app.kubernetes.io/component: frontend
+    app: precipitation1hr
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: precipitation1hr
+  template:
+    metadata:
+      labels:
+        app: precipitation1hr
+    spec:
+      containers:
+        - name: precipitation1hr
+          image: ghcr.io/noaa-gsl/mats/development/precipitation1hr:development
+          ports:
+            - containerPort: 9000
+          securityContext:
+            allowPrivilegeEscalation: false
+

--- a/kubernetes/base/precipitation1hr/kustomization.yaml
+++ b/kubernetes/base/precipitation1hr/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/kubernetes/base/precipitation1hr/service.yaml
+++ b/kubernetes/base/precipitation1hr/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: precipitation1hr
+  labels:
+    app: precipitation1hr
+spec:
+  selector:
+    app: precipitation1hr
+  ports:
+  - port: 80
+    targetPort: 9000
+    protocol: TCP
+    name: http
+  type: ClusterIP

--- a/kubernetes/base/ptype/deployment.yaml
+++ b/kubernetes/base/ptype/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ptype
+  labels:
+    app.kubernetes.io/name: ptype
+    app.kubernetes.io/part-of: mats
+    app.kubernetes.io/component: frontend
+    app: ptype
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ptype
+  template:
+    metadata:
+      labels:
+        app: ptype
+    spec:
+      containers:
+        - name: ptype
+          image: ghcr.io/noaa-gsl/mats/development/ptype:development
+          ports:
+            - containerPort: 9000
+          securityContext:
+            allowPrivilegeEscalation: false
+

--- a/kubernetes/base/ptype/kustomization.yaml
+++ b/kubernetes/base/ptype/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/kubernetes/base/ptype/service.yaml
+++ b/kubernetes/base/ptype/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ptype
+  labels:
+    app: ptype
+spec:
+  selector:
+    app: ptype
+  ports:
+  - port: 80
+    targetPort: 9000
+    protocol: TCP
+    name: http
+  type: ClusterIP

--- a/kubernetes/base/radar/deployment.yaml
+++ b/kubernetes/base/radar/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: radar
+  labels:
+    app.kubernetes.io/name: radar
+    app.kubernetes.io/part-of: mats
+    app.kubernetes.io/component: frontend
+    app: radar
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: radar
+  template:
+    metadata:
+      labels:
+        app: radar
+    spec:
+      containers:
+        - name: radar
+          image: ghcr.io/noaa-gsl/mats/development/radar:development
+          ports:
+            - containerPort: 9000
+          securityContext:
+            allowPrivilegeEscalation: false
+

--- a/kubernetes/base/radar/kustomization.yaml
+++ b/kubernetes/base/radar/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/kubernetes/base/radar/service.yaml
+++ b/kubernetes/base/radar/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: radar
+  labels:
+    app: radar
+spec:
+  selector:
+    app: radar
+  ports:
+  - port: 80
+    targetPort: 9000
+    protocol: TCP
+    name: http
+  type: ClusterIP

--- a/kubernetes/base/surface/deployment.yaml
+++ b/kubernetes/base/surface/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: surface
+  labels:
+    app.kubernetes.io/name: surface
+    app.kubernetes.io/part-of: mats
+    app.kubernetes.io/component: frontend
+    app: surface
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: surface
+  template:
+    metadata:
+      labels:
+        app: surface
+    spec:
+      containers:
+        - name: surface
+          image: ghcr.io/noaa-gsl/mats/development/surface:development
+          ports:
+            - containerPort: 9000
+          securityContext:
+            allowPrivilegeEscalation: false
+

--- a/kubernetes/base/surface/kustomization.yaml
+++ b/kubernetes/base/surface/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/kubernetes/base/surface/service.yaml
+++ b/kubernetes/base/surface/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: surface
+  labels:
+    app: surface
+spec:
+  selector:
+    app: surface
+  ports:
+  - port: 80
+    targetPort: 9000
+    protocol: TCP
+    name: http
+  type: ClusterIP

--- a/kubernetes/base/surfrad/deployment.yaml
+++ b/kubernetes/base/surfrad/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: surfrad
+  labels:
+    app.kubernetes.io/name: surfrad
+    app.kubernetes.io/part-of: mats
+    app.kubernetes.io/component: frontend
+    app: surfrad
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: surfrad
+  template:
+    metadata:
+      labels:
+        app: surfrad
+    spec:
+      containers:
+        - name: surfrad
+          image: ghcr.io/noaa-gsl/mats/development/surfrad:development
+          ports:
+            - containerPort: 9000
+          securityContext:
+            allowPrivilegeEscalation: false
+

--- a/kubernetes/base/surfrad/kustomization.yaml
+++ b/kubernetes/base/surfrad/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/kubernetes/base/surfrad/service.yaml
+++ b/kubernetes/base/surfrad/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: surfrad
+  labels:
+    app: surfrad
+spec:
+  selector:
+    app: surfrad
+  ports:
+  - port: 80
+    targetPort: 9000
+    protocol: TCP
+    name: http
+  type: ClusterIP

--- a/kubernetes/base/upperair/deployment.yaml
+++ b/kubernetes/base/upperair/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: upperair
+  labels:
+    app.kubernetes.io/name: upperair
+    app.kubernetes.io/part-of: mats
+    app.kubernetes.io/component: frontend
+    app: upperair
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: upperair
+  template:
+    metadata:
+      labels:
+        app: upperair
+    spec:
+      containers:
+        - name: upperair
+          image: ghcr.io/noaa-gsl/mats/development/upperair:development
+          ports:
+            - containerPort: 9000
+          securityContext:
+            allowPrivilegeEscalation: false
+

--- a/kubernetes/base/upperair/kustomization.yaml
+++ b/kubernetes/base/upperair/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/kubernetes/base/upperair/service.yaml
+++ b/kubernetes/base/upperair/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: upperair
+  labels:
+    app: upperair
+spec:
+  selector:
+    app: upperair
+  ports:
+  - port: 80
+    targetPort: 9000
+    protocol: TCP
+    name: http
+  type: ClusterIP

--- a/kubernetes/overlays/gsl-dev/anomalycor/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/anomalycor/deployment.yaml
@@ -22,6 +22,9 @@ spec:
               mountPath: /usr/app/settings/anomalycor/settings.json
               subPath: settings.json
               readOnly: true
+          imagePullPolicy: Always  # Since we track a long-lived tag
+      imagePullSecrets:
+        - name: mats-ghcr
       volumes:
         - name: anomalycor-settings-file
           configMap:

--- a/kubernetes/overlays/gsl-dev/anomalycor/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/anomalycor/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: anomalycor
+spec:
+  template:
+    spec:
+      containers:
+        - name: anomalycor
+          # resources:
+          #   requests:
+          #     memory: "2Gi"
+          #     cpu: "1"
+          #   limits:
+          #     memory: "4Gi"
+          #     cpu: "2"
+          envFrom:
+            - secretRef:
+                name: anomalycor-secret
+          volumeMounts:
+            - name: anomalycor-settings-file
+              mountPath: /usr/app/settings/anomalycor/settings.json
+              subPath: settings.json
+              readOnly: true
+      volumes:
+        - name: anomalycor-settings-file
+          configMap:
+            name: anomalycor-config

--- a/kubernetes/overlays/gsl-dev/anomalycor/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/anomalycor/deployment.yaml
@@ -9,8 +9,8 @@ spec:
         - name: anomalycor
           resources:
             requests:
-              memory: "2Gi"
-              cpu: "1"
+              memory: "1Gi"
+              cpu: "0.25"
             limits:
               memory: "8Gi"
               cpu: "4"

--- a/kubernetes/overlays/gsl-dev/anomalycor/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/anomalycor/deployment.yaml
@@ -7,13 +7,13 @@ spec:
     spec:
       containers:
         - name: anomalycor
-          # resources:
-          #   requests:
-          #     memory: "2Gi"
-          #     cpu: "1"
-          #   limits:
-          #     memory: "4Gi"
-          #     cpu: "2"
+          resources:
+            requests:
+              memory: "2Gi"
+              cpu: "1"
+            limits:
+              memory: "8Gi"
+              cpu: "4"
           envFrom:
             - secretRef:
                 name: anomalycor-secret

--- a/kubernetes/overlays/gsl-dev/anomalycor/kustomization.yaml
+++ b/kubernetes/overlays/gsl-dev/anomalycor/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - ../../../base/anomalycor
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: ghcr.io/noaa-gsl/mats/development/anomalycor
+    newTag: development 
+
+configMapGenerator:
+  - name: anomalycor-config
+    files:
+      - settings.json # Should mirror the appropriate settings.json file in mats-settings
+
+secretGenerator:
+  - name: anomalycor-secret
+    envs:
+      - .env # Should contain mongo_url, root_url, and delay

--- a/kubernetes/overlays/gsl-dev/cb-ceiling/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/cb-ceiling/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cb-ceiling
+spec:
+  template:
+    spec:
+      containers:
+        - name: cb-ceiling
+          # resources:
+          #   requests:
+          #     memory: "2Gi"
+          #     cpu: "1"
+          #   limits:
+          #     memory: "4Gi"
+          #     cpu: "2"
+          envFrom:
+            - secretRef:
+                name: cb-ceiling-secret
+          volumeMounts:
+            - name: cb-ceiling-settings-file
+              mountPath: /usr/app/settings/cb-ceiling/settings.json
+              subPath: settings.json
+              readOnly: true
+      volumes:
+        - name: cb-ceiling-settings-file
+          configMap:
+            name: cb-ceiling-config

--- a/kubernetes/overlays/gsl-dev/cb-ceiling/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/cb-ceiling/deployment.yaml
@@ -9,8 +9,8 @@ spec:
         - name: cb-ceiling
           resources:
             requests:
-              memory: "2Gi"
-              cpu: "1"
+              memory: "1Gi"
+              cpu: "0.25"
             limits:
               memory: "8Gi"
               cpu: "4"

--- a/kubernetes/overlays/gsl-dev/cb-ceiling/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/cb-ceiling/deployment.yaml
@@ -22,6 +22,9 @@ spec:
               mountPath: /usr/app/settings/cb-ceiling/settings.json
               subPath: settings.json
               readOnly: true
+          imagePullPolicy: Always  # Since we track a long-lived tag
+      imagePullSecrets:
+        - name: mats-ghcr
       volumes:
         - name: cb-ceiling-settings-file
           configMap:

--- a/kubernetes/overlays/gsl-dev/cb-ceiling/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/cb-ceiling/deployment.yaml
@@ -7,13 +7,13 @@ spec:
     spec:
       containers:
         - name: cb-ceiling
-          # resources:
-          #   requests:
-          #     memory: "2Gi"
-          #     cpu: "1"
-          #   limits:
-          #     memory: "4Gi"
-          #     cpu: "2"
+          resources:
+            requests:
+              memory: "2Gi"
+              cpu: "1"
+            limits:
+              memory: "8Gi"
+              cpu: "4"
           envFrom:
             - secretRef:
                 name: cb-ceiling-secret

--- a/kubernetes/overlays/gsl-dev/cb-ceiling/kustomization.yaml
+++ b/kubernetes/overlays/gsl-dev/cb-ceiling/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - ../../../base/cb-ceiling
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: ghcr.io/noaa-gsl/mats/development/cb-ceiling
+    newTag: development 
+
+configMapGenerator:
+  - name: cb-ceiling-config
+    files:
+      - settings.json # Should mirror the appropriate settings.json file in mats-settings
+
+secretGenerator:
+  - name: cb-ceiling-secret
+    envs:
+      - .env # Should contain mongo_url, root_url, and delay

--- a/kubernetes/overlays/gsl-dev/ceil-vis/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/ceil-vis/deployment.yaml
@@ -22,6 +22,9 @@ spec:
               mountPath: /usr/app/settings/ceil-vis/settings.json
               subPath: settings.json
               readOnly: true
+          imagePullPolicy: Always  # Since we track a long-lived tag
+      imagePullSecrets:
+        - name: mats-ghcr
       volumes:
         - name: ceil-vis-settings-file
           configMap:

--- a/kubernetes/overlays/gsl-dev/ceil-vis/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/ceil-vis/deployment.yaml
@@ -7,13 +7,13 @@ spec:
     spec:
       containers:
         - name: ceil-vis
-          # resources:
-          #   requests:
-          #     memory: "2Gi"
-          #     cpu: "1"
-          #   limits:
-          #     memory: "4Gi"
-          #     cpu: "2"
+          resources:
+            requests:
+              memory: "2Gi"
+              cpu: "1"
+            limits:
+              memory: "8Gi"
+              cpu: "4"
           envFrom:
             - secretRef:
                 name: ceil-vis-secret

--- a/kubernetes/overlays/gsl-dev/ceil-vis/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/ceil-vis/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ceil-vis
+spec:
+  template:
+    spec:
+      containers:
+        - name: ceil-vis
+          # resources:
+          #   requests:
+          #     memory: "2Gi"
+          #     cpu: "1"
+          #   limits:
+          #     memory: "4Gi"
+          #     cpu: "2"
+          envFrom:
+            - secretRef:
+                name: ceil-vis-secret
+          volumeMounts:
+            - name: ceil-vis-settings-file
+              mountPath: /usr/app/settings/ceil-vis/settings.json
+              subPath: settings.json
+              readOnly: true
+      volumes:
+        - name: ceil-vis-settings-file
+          configMap:
+            name: ceil-vis-config

--- a/kubernetes/overlays/gsl-dev/ceil-vis/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/ceil-vis/deployment.yaml
@@ -9,8 +9,8 @@ spec:
         - name: ceil-vis
           resources:
             requests:
-              memory: "2Gi"
-              cpu: "1"
+              memory: "1Gi"
+              cpu: "0.25"
             limits:
               memory: "8Gi"
               cpu: "4"

--- a/kubernetes/overlays/gsl-dev/ceil-vis/kustomization.yaml
+++ b/kubernetes/overlays/gsl-dev/ceil-vis/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - ../../../base/ceil-vis
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: ghcr.io/noaa-gsl/mats/development/ceil-vis
+    newTag: development 
+
+configMapGenerator:
+  - name: ceil-vis-config
+    files:
+      - settings.json # Should mirror the appropriate settings.json file in mats-settings
+
+secretGenerator:
+  - name: ceil-vis-secret
+    envs:
+      - .env # Should contain mongo_url, root_url, and delay

--- a/kubernetes/overlays/gsl-dev/ceil-vis15/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/ceil-vis15/deployment.yaml
@@ -9,8 +9,8 @@ spec:
         - name: ceil-vis15
           resources:
             requests:
-              memory: "2Gi"
-              cpu: "1"
+              memory: "1Gi"
+              cpu: "0.25"
             limits:
               memory: "8Gi"
               cpu: "4"

--- a/kubernetes/overlays/gsl-dev/ceil-vis15/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/ceil-vis15/deployment.yaml
@@ -22,6 +22,9 @@ spec:
               mountPath: /usr/app/settings/ceil-vis15/settings.json
               subPath: settings.json
               readOnly: true
+          imagePullPolicy: Always  # Since we track a long-lived tag
+      imagePullSecrets:
+        - name: mats-ghcr
       volumes:
         - name: ceil-vis15-settings-file
           configMap:

--- a/kubernetes/overlays/gsl-dev/ceil-vis15/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/ceil-vis15/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ceil-vis15
+spec:
+  template:
+    spec:
+      containers:
+        - name: ceil-vis15
+          # resources:
+          #   requests:
+          #     memory: "2Gi"
+          #     cpu: "1"
+          #   limits:
+          #     memory: "4Gi"
+          #     cpu: "2"
+          envFrom:
+            - secretRef:
+                name: ceil-vis15-secret
+          volumeMounts:
+            - name: ceil-vis15-settings-file
+              mountPath: /usr/app/settings/ceil-vis15/settings.json
+              subPath: settings.json
+              readOnly: true
+      volumes:
+        - name: ceil-vis15-settings-file
+          configMap:
+            name: ceil-vis15-config

--- a/kubernetes/overlays/gsl-dev/ceil-vis15/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/ceil-vis15/deployment.yaml
@@ -7,13 +7,13 @@ spec:
     spec:
       containers:
         - name: ceil-vis15
-          # resources:
-          #   requests:
-          #     memory: "2Gi"
-          #     cpu: "1"
-          #   limits:
-          #     memory: "4Gi"
-          #     cpu: "2"
+          resources:
+            requests:
+              memory: "2Gi"
+              cpu: "1"
+            limits:
+              memory: "8Gi"
+              cpu: "4"
           envFrom:
             - secretRef:
                 name: ceil-vis15-secret

--- a/kubernetes/overlays/gsl-dev/ceil-vis15/kustomization.yaml
+++ b/kubernetes/overlays/gsl-dev/ceil-vis15/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - ../../../base/ceil-vis15
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: ghcr.io/noaa-gsl/mats/development/ceil-vis15
+    newTag: development 
+
+configMapGenerator:
+  - name: ceil-vis15-config
+    files:
+      - settings.json # Should mirror the appropriate settings.json file in mats-settings
+
+secretGenerator:
+  - name: ceil-vis15-secret
+    envs:
+      - .env # Should contain mongo_url, root_url, and delay

--- a/kubernetes/overlays/gsl-dev/ingress.yaml
+++ b/kubernetes/overlays/gsl-dev/ingress.yaml
@@ -53,3 +53,59 @@ spec:
                 name: landuse
                 port:
                   number: 80
+          - path: /mats-dev/precipaccum
+            pathType: Prefix
+            backend:
+              service:
+                name: precipaccum
+                port:
+                  number: 80
+          - path: /mats-dev/precipgauge
+            pathType: Prefix
+            backend:
+              service:
+                name: precipgauge
+                port:
+                  number: 80
+          - path: /mats-dev/precipitation1hr
+            pathType: Prefix
+            backend:
+              service:
+                name: precipitation1hr
+                port:
+                  number: 80
+          - path: /mats-dev/ptype
+            pathType: Prefix
+            backend:
+              service:
+                name: ptype
+                port:
+                  number: 80
+          - path: /mats-dev/radar
+            pathType: Prefix
+            backend:
+              service:
+                name: radar
+                port:
+                  number: 80
+          - path: /mats-dev/surface
+            pathType: Prefix
+            backend:
+              service:
+                name: surface
+                port:
+                  number: 80
+          - path: /mats-dev/surfrad
+            pathType: Prefix
+            backend:
+              service:
+                name: surfrad
+                port:
+                  number: 80
+          - path: /mats-dev/upperair
+            pathType: Prefix
+            backend:
+              service:
+                name: upperair
+                port:
+                  number: 80

--- a/kubernetes/overlays/gsl-dev/ingress.yaml
+++ b/kubernetes/overlays/gsl-dev/ingress.yaml
@@ -25,3 +25,31 @@ spec:
                 name: anomalycor
                 port:
                   name: http
+          - path: /mats-dev/cb-ceiling
+            pathType: Prefix
+            backend:
+              service:
+                name: cb-ceiling
+                port:
+                  number: 80
+          - path: /mats-dev/ceil-vis
+            pathType: Prefix
+            backend:
+              service:
+                name: ceil-vis
+                port:
+                  number: 80
+          - path: /mats-dev/ceil-vis15
+            pathType: Prefix
+            backend:
+              service:
+                name: ceil-vis15
+                port:
+                  number: 80
+          - path: /mats-dev/landuse
+            pathType: Prefix
+            backend:
+              service:
+                name: landuse
+                port:
+                  number: 80

--- a/kubernetes/overlays/gsl-dev/ingress.yaml
+++ b/kubernetes/overlays/gsl-dev/ingress.yaml
@@ -18,3 +18,10 @@ spec:
                 name: scorecard
                 port:
                   name: http
+          - path: /mats-dev/anomalycor
+            pathType: Prefix
+            backend:
+              service:
+                name: anomalycor
+                port:
+                  name: http

--- a/kubernetes/overlays/gsl-dev/kustomization.yaml
+++ b/kubernetes/overlays/gsl-dev/kustomization.yaml
@@ -4,7 +4,15 @@ resources:
   - ceil-vis
   - ceil-vis15
   - landuse
+  - precipAccum
+  - precipGauge
+  - precipitation1hr
+  - ptype
+  - radar
   - scorecard
+  - surface
+  - surfrad
+  - upperair
   - mongo
   - ingress.yaml
 commonLabels:

--- a/kubernetes/overlays/gsl-dev/kustomization.yaml
+++ b/kubernetes/overlays/gsl-dev/kustomization.yaml
@@ -1,5 +1,9 @@
 resources:
   - anomalycor
+  - cb-ceiling
+  - ceil-vis
+  - ceil-vis15
+  - landuse
   - scorecard
   - mongo
   - ingress.yaml

--- a/kubernetes/overlays/gsl-dev/kustomization.yaml
+++ b/kubernetes/overlays/gsl-dev/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+  - anomalycor
   - scorecard
   - mongo
   - ingress.yaml

--- a/kubernetes/overlays/gsl-dev/landuse/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/landuse/deployment.yaml
@@ -9,8 +9,8 @@ spec:
         - name: landuse
           resources:
             requests:
-              memory: "2Gi"
-              cpu: "1"
+              memory: "1Gi"
+              cpu: "0.25"
             limits:
               memory: "8Gi"
               cpu: "4"

--- a/kubernetes/overlays/gsl-dev/landuse/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/landuse/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: landuse
+spec:
+  template:
+    spec:
+      containers:
+        - name: landuse
+          # resources:
+          #   requests:
+          #     memory: "2Gi"
+          #     cpu: "1"
+          #   limits:
+          #     memory: "4Gi"
+          #     cpu: "2"
+          envFrom:
+            - secretRef:
+                name: landuse-secret
+          volumeMounts:
+            - name: landuse-settings-file
+              mountPath: /usr/app/settings/landuse/settings.json
+              subPath: settings.json
+              readOnly: true
+      volumes:
+        - name: landuse-settings-file
+          configMap:
+            name: landuse-config

--- a/kubernetes/overlays/gsl-dev/landuse/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/landuse/deployment.yaml
@@ -7,13 +7,13 @@ spec:
     spec:
       containers:
         - name: landuse
-          # resources:
-          #   requests:
-          #     memory: "2Gi"
-          #     cpu: "1"
-          #   limits:
-          #     memory: "4Gi"
-          #     cpu: "2"
+          resources:
+            requests:
+              memory: "2Gi"
+              cpu: "1"
+            limits:
+              memory: "8Gi"
+              cpu: "4"
           envFrom:
             - secretRef:
                 name: landuse-secret

--- a/kubernetes/overlays/gsl-dev/landuse/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/landuse/deployment.yaml
@@ -22,6 +22,9 @@ spec:
               mountPath: /usr/app/settings/landuse/settings.json
               subPath: settings.json
               readOnly: true
+          imagePullPolicy: Always  # Since we track a long-lived tag
+      imagePullSecrets:
+        - name: mats-ghcr
       volumes:
         - name: landuse-settings-file
           configMap:

--- a/kubernetes/overlays/gsl-dev/landuse/kustomization.yaml
+++ b/kubernetes/overlays/gsl-dev/landuse/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - ../../../base/landuse
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: ghcr.io/noaa-gsl/mats/development/landuse
+    newTag: development 
+
+configMapGenerator:
+  - name: landuse-config
+    files:
+      - settings.json # Should mirror the appropriate settings.json file in mats-settings
+
+secretGenerator:
+  - name: landuse-secret
+    envs:
+      - .env # Should contain mongo_url, root_url, and delay

--- a/kubernetes/overlays/gsl-dev/mongo/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/mongo/deployment.yaml
@@ -7,6 +7,13 @@ spec:
     spec:
       containers:
         - name: mongodb
+          resources:
+            requests:
+              memory: "2Gi"
+              cpu: "1"
+            limits:
+              memory: "2Gi"
+              cpu: "1"
           envFrom:
             - secretRef:
                 name: mongo-secret

--- a/kubernetes/overlays/gsl-dev/precipAccum/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/precipAccum/deployment.yaml
@@ -7,13 +7,13 @@ spec:
     spec:
       containers:
         - name: precipaccum
-          # resources:
-          #   requests:
-          #     memory: "2Gi"
-          #     cpu: "1"
-          #   limits:
-          #     memory: "4Gi"
-          #     cpu: "2"
+          resources:
+            requests:
+              memory: "2Gi"
+              cpu: "1"
+            limits:
+              memory: "8Gi"
+              cpu: "4"
           envFrom:
             - secretRef:
                 name: precipaccum-secret

--- a/kubernetes/overlays/gsl-dev/precipAccum/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/precipAccum/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: precipaccum
+spec:
+  template:
+    spec:
+      containers:
+        - name: precipaccum
+          # resources:
+          #   requests:
+          #     memory: "2Gi"
+          #     cpu: "1"
+          #   limits:
+          #     memory: "4Gi"
+          #     cpu: "2"
+          envFrom:
+            - secretRef:
+                name: precipaccum-secret
+          volumeMounts:
+            - name: precipaccum-settings-file
+              mountPath: /usr/app/settings/precipAccum/settings.json
+              subPath: settings.json
+              readOnly: true
+      volumes:
+        - name: precipaccum-settings-file
+          configMap:
+            name: precipaccum-config

--- a/kubernetes/overlays/gsl-dev/precipAccum/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/precipAccum/deployment.yaml
@@ -9,8 +9,8 @@ spec:
         - name: precipaccum
           resources:
             requests:
-              memory: "2Gi"
-              cpu: "1"
+              memory: "1Gi"
+              cpu: "0.25"
             limits:
               memory: "8Gi"
               cpu: "4"

--- a/kubernetes/overlays/gsl-dev/precipAccum/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/precipAccum/deployment.yaml
@@ -22,6 +22,9 @@ spec:
               mountPath: /usr/app/settings/precipAccum/settings.json
               subPath: settings.json
               readOnly: true
+          imagePullPolicy: Always  # Since we track a long-lived tag
+      imagePullSecrets:
+        - name: mats-ghcr
       volumes:
         - name: precipaccum-settings-file
           configMap:

--- a/kubernetes/overlays/gsl-dev/precipAccum/kustomization.yaml
+++ b/kubernetes/overlays/gsl-dev/precipAccum/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - ../../../base/precipAccum
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: ghcr.io/noaa-gsl/mats/development/precipaccum
+    newTag: development 
+
+configMapGenerator:
+  - name: precipaccum-config
+    files:
+      - settings.json # Should mirror the appropriate settings.json file in mats-settings
+
+secretGenerator:
+  - name: precipaccum-secret
+    envs:
+      - .env # Should contain mongo_url, root_url, and delay

--- a/kubernetes/overlays/gsl-dev/precipGauge/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/precipGauge/deployment.yaml
@@ -7,13 +7,13 @@ spec:
     spec:
       containers:
         - name: precipgauge
-          # resources:
-          #   requests:
-          #     memory: "2Gi"
-          #     cpu: "1"
-          #   limits:
-          #     memory: "4Gi"
-          #     cpu: "2"
+          resources:
+            requests:
+              memory: "2Gi"
+              cpu: "1"
+            limits:
+              memory: "8Gi"
+              cpu: "4"
           envFrom:
             - secretRef:
                 name: precipgauge-secret

--- a/kubernetes/overlays/gsl-dev/precipGauge/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/precipGauge/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: precipgauge
+spec:
+  template:
+    spec:
+      containers:
+        - name: precipgauge
+          # resources:
+          #   requests:
+          #     memory: "2Gi"
+          #     cpu: "1"
+          #   limits:
+          #     memory: "4Gi"
+          #     cpu: "2"
+          envFrom:
+            - secretRef:
+                name: precipgauge-secret
+          volumeMounts:
+            - name: precipgauge-settings-file
+              mountPath: /usr/app/settings/precipGauge/settings.json
+              subPath: settings.json
+              readOnly: true
+      volumes:
+        - name: precipgauge-settings-file
+          configMap:
+            name: precipgauge-config

--- a/kubernetes/overlays/gsl-dev/precipGauge/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/precipGauge/deployment.yaml
@@ -22,6 +22,9 @@ spec:
               mountPath: /usr/app/settings/precipGauge/settings.json
               subPath: settings.json
               readOnly: true
+          imagePullPolicy: Always  # Since we track a long-lived tag
+      imagePullSecrets:
+        - name: mats-ghcr
       volumes:
         - name: precipgauge-settings-file
           configMap:

--- a/kubernetes/overlays/gsl-dev/precipGauge/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/precipGauge/deployment.yaml
@@ -9,8 +9,8 @@ spec:
         - name: precipgauge
           resources:
             requests:
-              memory: "2Gi"
-              cpu: "1"
+              memory: "1Gi"
+              cpu: "0.25"
             limits:
               memory: "8Gi"
               cpu: "4"

--- a/kubernetes/overlays/gsl-dev/precipGauge/kustomization.yaml
+++ b/kubernetes/overlays/gsl-dev/precipGauge/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - ../../../base/precipgauge
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: ghcr.io/noaa-gsl/mats/development/precipgauge
+    newTag: development 
+
+configMapGenerator:
+  - name: precipgauge-config
+    files:
+      - settings.json # Should mirror the appropriate settings.json file in mats-settings
+
+secretGenerator:
+  - name: precipgauge-secret
+    envs:
+      - .env # Should contain mongo_url, root_url, and delay

--- a/kubernetes/overlays/gsl-dev/precipitation1hr/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/precipitation1hr/deployment.yaml
@@ -7,13 +7,13 @@ spec:
     spec:
       containers:
         - name: precipitation1hr
-          # resources:
-          #   requests:
-          #     memory: "2Gi"
-          #     cpu: "1"
-          #   limits:
-          #     memory: "4Gi"
-          #     cpu: "2"
+          resources:
+            requests:
+              memory: "2Gi"
+              cpu: "1"
+            limits:
+              memory: "8Gi"
+              cpu: "4"
           envFrom:
             - secretRef:
                 name: precipitation1hr-secret

--- a/kubernetes/overlays/gsl-dev/precipitation1hr/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/precipitation1hr/deployment.yaml
@@ -9,8 +9,8 @@ spec:
         - name: precipitation1hr
           resources:
             requests:
-              memory: "2Gi"
-              cpu: "1"
+              memory: "1Gi"
+              cpu: "0.25"
             limits:
               memory: "8Gi"
               cpu: "4"

--- a/kubernetes/overlays/gsl-dev/precipitation1hr/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/precipitation1hr/deployment.yaml
@@ -22,6 +22,9 @@ spec:
               mountPath: /usr/app/settings/precipitation1hr/settings.json
               subPath: settings.json
               readOnly: true
+          imagePullPolicy: Always  # Since we track a long-lived tag
+      imagePullSecrets:
+        - name: mats-ghcr
       volumes:
         - name: precipitation1hr-settings-file
           configMap:

--- a/kubernetes/overlays/gsl-dev/precipitation1hr/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/precipitation1hr/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: precipitation1hr
+spec:
+  template:
+    spec:
+      containers:
+        - name: precipitation1hr
+          # resources:
+          #   requests:
+          #     memory: "2Gi"
+          #     cpu: "1"
+          #   limits:
+          #     memory: "4Gi"
+          #     cpu: "2"
+          envFrom:
+            - secretRef:
+                name: precipitation1hr-secret
+          volumeMounts:
+            - name: precipitation1hr-settings-file
+              mountPath: /usr/app/settings/precipitation1hr/settings.json
+              subPath: settings.json
+              readOnly: true
+      volumes:
+        - name: precipitation1hr-settings-file
+          configMap:
+            name: precipitation1hr-config

--- a/kubernetes/overlays/gsl-dev/precipitation1hr/kustomization.yaml
+++ b/kubernetes/overlays/gsl-dev/precipitation1hr/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - ../../../base/precipitation1hr
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: ghcr.io/noaa-gsl/mats/development/precipitation1hr
+    newTag: development 
+
+configMapGenerator:
+  - name: precipitation1hr-config
+    files:
+      - settings.json # Should mirror the appropriate settings.json file in mats-settings
+
+secretGenerator:
+  - name: precipitation1hr-secret
+    envs:
+      - .env # Should contain mongo_url, root_url, and delay

--- a/kubernetes/overlays/gsl-dev/ptype/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/ptype/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ptype
+spec:
+  template:
+    spec:
+      containers:
+        - name: ptype
+          # resources:
+          #   requests:
+          #     memory: "2Gi"
+          #     cpu: "1"
+          #   limits:
+          #     memory: "4Gi"
+          #     cpu: "2"
+          envFrom:
+            - secretRef:
+                name: ptype-secret
+          volumeMounts:
+            - name: ptype-settings-file
+              mountPath: /usr/app/settings/ptype/settings.json
+              subPath: settings.json
+              readOnly: true
+      volumes:
+        - name: ptype-settings-file
+          configMap:
+            name: ptype-config

--- a/kubernetes/overlays/gsl-dev/ptype/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/ptype/deployment.yaml
@@ -9,8 +9,8 @@ spec:
         - name: ptype
           resources:
             requests:
-              memory: "2Gi"
-              cpu: "1"
+              memory: "1Gi"
+              cpu: "0.25"
             limits:
               memory: "8Gi"
               cpu: "4"

--- a/kubernetes/overlays/gsl-dev/ptype/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/ptype/deployment.yaml
@@ -22,6 +22,9 @@ spec:
               mountPath: /usr/app/settings/ptype/settings.json
               subPath: settings.json
               readOnly: true
+          imagePullPolicy: Always  # Since we track a long-lived tag
+      imagePullSecrets:
+        - name: mats-ghcr
       volumes:
         - name: ptype-settings-file
           configMap:

--- a/kubernetes/overlays/gsl-dev/ptype/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/ptype/deployment.yaml
@@ -7,13 +7,13 @@ spec:
     spec:
       containers:
         - name: ptype
-          # resources:
-          #   requests:
-          #     memory: "2Gi"
-          #     cpu: "1"
-          #   limits:
-          #     memory: "4Gi"
-          #     cpu: "2"
+          resources:
+            requests:
+              memory: "2Gi"
+              cpu: "1"
+            limits:
+              memory: "8Gi"
+              cpu: "4"
           envFrom:
             - secretRef:
                 name: ptype-secret

--- a/kubernetes/overlays/gsl-dev/ptype/kustomization.yaml
+++ b/kubernetes/overlays/gsl-dev/ptype/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - ../../../base/ptype
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: ghcr.io/noaa-gsl/mats/development/ptype
+    newTag: development 
+
+configMapGenerator:
+  - name: ptype-config
+    files:
+      - settings.json # Should mirror the appropriate settings.json file in mats-settings
+
+secretGenerator:
+  - name: ptype-secret
+    envs:
+      - .env # Should contain mongo_url, root_url, and delay

--- a/kubernetes/overlays/gsl-dev/radar/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/radar/deployment.yaml
@@ -9,8 +9,8 @@ spec:
         - name: radar
           resources:
             requests:
-              memory: "2Gi"
-              cpu: "1"
+              memory: "1Gi"
+              cpu: "0.25"
             limits:
               memory: "8Gi"
               cpu: "4"

--- a/kubernetes/overlays/gsl-dev/radar/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/radar/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: radar
+spec:
+  template:
+    spec:
+      containers:
+        - name: radar
+          # resources:
+          #   requests:
+          #     memory: "2Gi"
+          #     cpu: "1"
+          #   limits:
+          #     memory: "4Gi"
+          #     cpu: "2"
+          envFrom:
+            - secretRef:
+                name: radar-secret
+          volumeMounts:
+            - name: radar-settings-file
+              mountPath: /usr/app/settings/radar/settings.json
+              subPath: settings.json
+              readOnly: true
+      volumes:
+        - name: radar-settings-file
+          configMap:
+            name: radar-config

--- a/kubernetes/overlays/gsl-dev/radar/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/radar/deployment.yaml
@@ -7,13 +7,13 @@ spec:
     spec:
       containers:
         - name: radar
-          # resources:
-          #   requests:
-          #     memory: "2Gi"
-          #     cpu: "1"
-          #   limits:
-          #     memory: "4Gi"
-          #     cpu: "2"
+          resources:
+            requests:
+              memory: "2Gi"
+              cpu: "1"
+            limits:
+              memory: "8Gi"
+              cpu: "4"
           envFrom:
             - secretRef:
                 name: radar-secret

--- a/kubernetes/overlays/gsl-dev/radar/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/radar/deployment.yaml
@@ -22,6 +22,9 @@ spec:
               mountPath: /usr/app/settings/radar/settings.json
               subPath: settings.json
               readOnly: true
+          imagePullPolicy: Always  # Since we track a long-lived tag
+      imagePullSecrets:
+        - name: mats-ghcr
       volumes:
         - name: radar-settings-file
           configMap:

--- a/kubernetes/overlays/gsl-dev/radar/kustomization.yaml
+++ b/kubernetes/overlays/gsl-dev/radar/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - ../../../base/radar
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: ghcr.io/noaa-gsl/mats/development/radar
+    newTag: development 
+
+configMapGenerator:
+  - name: radar-config
+    files:
+      - settings.json # Should mirror the appropriate settings.json file in mats-settings
+
+secretGenerator:
+  - name: radar-secret
+    envs:
+      - .env # Should contain mongo_url, root_url, and delay

--- a/kubernetes/overlays/gsl-dev/scorecard/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/scorecard/deployment.yaml
@@ -15,6 +15,9 @@ spec:
               mountPath: /usr/app/settings/scorecard/settings.json
               subPath: settings.json
               readOnly: true
+          imagePullPolicy: Always  # Since we track a long-lived tag
+      imagePullSecrets:
+        - name: mats-ghcr
       volumes:
         - name: scorecard-settings-file
           configMap:

--- a/kubernetes/overlays/gsl-dev/scorecard/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/scorecard/deployment.yaml
@@ -7,6 +7,13 @@ spec:
     spec:
       containers:
         - name: scorecard
+          resources:
+            requests:
+              memory: "2Gi"
+              cpu: "1"
+            limits:
+              memory: "8Gi"
+              cpu: "4"
           envFrom:
             - secretRef:
                 name: scorecard-secret

--- a/kubernetes/overlays/gsl-dev/scorecard/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/scorecard/deployment.yaml
@@ -9,8 +9,8 @@ spec:
         - name: scorecard
           resources:
             requests:
-              memory: "2Gi"
-              cpu: "1"
+              memory: "1Gi"
+              cpu: "0.25"
             limits:
               memory: "8Gi"
               cpu: "4"

--- a/kubernetes/overlays/gsl-dev/surface/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/surface/deployment.yaml
@@ -22,6 +22,9 @@ spec:
               mountPath: /usr/app/settings/surface/settings.json
               subPath: settings.json
               readOnly: true
+          imagePullPolicy: Always  # Since we track a long-lived tag
+      imagePullSecrets:
+        - name: mats-ghcr
       volumes:
         - name: surface-settings-file
           configMap:

--- a/kubernetes/overlays/gsl-dev/surface/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/surface/deployment.yaml
@@ -7,13 +7,13 @@ spec:
     spec:
       containers:
         - name: surface
-          # resources:
-          #   requests:
-          #     memory: "2Gi"
-          #     cpu: "1"
-          #   limits:
-          #     memory: "4Gi"
-          #     cpu: "2"
+          resources:
+            requests:
+              memory: "2Gi"
+              cpu: "1"
+            limits:
+              memory: "8Gi"
+              cpu: "4"
           envFrom:
             - secretRef:
                 name: surface-secret

--- a/kubernetes/overlays/gsl-dev/surface/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/surface/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: surface
+spec:
+  template:
+    spec:
+      containers:
+        - name: surface
+          # resources:
+          #   requests:
+          #     memory: "2Gi"
+          #     cpu: "1"
+          #   limits:
+          #     memory: "4Gi"
+          #     cpu: "2"
+          envFrom:
+            - secretRef:
+                name: surface-secret
+          volumeMounts:
+            - name: surface-settings-file
+              mountPath: /usr/app/settings/surface/settings.json
+              subPath: settings.json
+              readOnly: true
+      volumes:
+        - name: surface-settings-file
+          configMap:
+            name: surface-config

--- a/kubernetes/overlays/gsl-dev/surface/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/surface/deployment.yaml
@@ -9,8 +9,8 @@ spec:
         - name: surface
           resources:
             requests:
-              memory: "2Gi"
-              cpu: "1"
+              memory: "1Gi"
+              cpu: "0.25"
             limits:
               memory: "8Gi"
               cpu: "4"

--- a/kubernetes/overlays/gsl-dev/surface/kustomization.yaml
+++ b/kubernetes/overlays/gsl-dev/surface/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - ../../../base/surface
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: ghcr.io/noaa-gsl/mats/development/surface
+    newTag: development 
+
+configMapGenerator:
+  - name: surface-config
+    files:
+      - settings.json # Should mirror the appropriate settings.json file in mats-settings
+
+secretGenerator:
+  - name: surface-secret
+    envs:
+      - .env # Should contain mongo_url, root_url, and delay

--- a/kubernetes/overlays/gsl-dev/surfrad/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/surfrad/deployment.yaml
@@ -7,13 +7,13 @@ spec:
     spec:
       containers:
         - name: surfrad
-          # resources:
-          #   requests:
-          #     memory: "2Gi"
-          #     cpu: "1"
-          #   limits:
-          #     memory: "4Gi"
-          #     cpu: "2"
+          resources:
+            requests:
+              memory: "2Gi"
+              cpu: "1"
+            limits:
+              memory: "8Gi"
+              cpu: "4"
           envFrom:
             - secretRef:
                 name: surfrad-secret

--- a/kubernetes/overlays/gsl-dev/surfrad/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/surfrad/deployment.yaml
@@ -22,6 +22,9 @@ spec:
               mountPath: /usr/app/settings/surfrad/settings.json
               subPath: settings.json
               readOnly: true
+          imagePullPolicy: Always  # Since we track a long-lived tag
+      imagePullSecrets:
+        - name: mats-ghcr
       volumes:
         - name: surfrad-settings-file
           configMap:

--- a/kubernetes/overlays/gsl-dev/surfrad/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/surfrad/deployment.yaml
@@ -9,8 +9,8 @@ spec:
         - name: surfrad
           resources:
             requests:
-              memory: "2Gi"
-              cpu: "1"
+              memory: "1Gi"
+              cpu: "0.25"
             limits:
               memory: "8Gi"
               cpu: "4"

--- a/kubernetes/overlays/gsl-dev/surfrad/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/surfrad/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: surfrad
+spec:
+  template:
+    spec:
+      containers:
+        - name: surfrad
+          # resources:
+          #   requests:
+          #     memory: "2Gi"
+          #     cpu: "1"
+          #   limits:
+          #     memory: "4Gi"
+          #     cpu: "2"
+          envFrom:
+            - secretRef:
+                name: surfrad-secret
+          volumeMounts:
+            - name: surfrad-settings-file
+              mountPath: /usr/app/settings/surfrad/settings.json
+              subPath: settings.json
+              readOnly: true
+      volumes:
+        - name: surfrad-settings-file
+          configMap:
+            name: surfrad-config

--- a/kubernetes/overlays/gsl-dev/surfrad/kustomization.yaml
+++ b/kubernetes/overlays/gsl-dev/surfrad/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - ../../../base/surfrad
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: ghcr.io/noaa-gsl/mats/development/surfrad
+    newTag: development 
+
+configMapGenerator:
+  - name: surfrad-config
+    files:
+      - settings.json # Should mirror the appropriate settings.json file in mats-settings
+
+secretGenerator:
+  - name: surfrad-secret
+    envs:
+      - .env # Should contain mongo_url, root_url, and delay

--- a/kubernetes/overlays/gsl-dev/upperair/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/upperair/deployment.yaml
@@ -22,6 +22,9 @@ spec:
               mountPath: /usr/app/settings/upperair/settings.json
               subPath: settings.json
               readOnly: true
+          imagePullPolicy: Always  # Since we track a long-lived tag
+      imagePullSecrets:
+        - name: mats-ghcr
       volumes:
         - name: upperair-settings-file
           configMap:

--- a/kubernetes/overlays/gsl-dev/upperair/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/upperair/deployment.yaml
@@ -9,8 +9,8 @@ spec:
         - name: upperair
           resources:
             requests:
-              memory: "2Gi"
-              cpu: "1"
+              memory: "1Gi"
+              cpu: "0.25"
             limits:
               memory: "8Gi"
               cpu: "4"

--- a/kubernetes/overlays/gsl-dev/upperair/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/upperair/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: upperair
+spec:
+  template:
+    spec:
+      containers:
+        - name: upperair
+          # resources:
+          #   requests:
+          #     memory: "2Gi"
+          #     cpu: "1"
+          #   limits:
+          #     memory: "4Gi"
+          #     cpu: "2"
+          envFrom:
+            - secretRef:
+                name: upperair-secret
+          volumeMounts:
+            - name: upperair-settings-file
+              mountPath: /usr/app/settings/upperair/settings.json
+              subPath: settings.json
+              readOnly: true
+      volumes:
+        - name: upperair-settings-file
+          configMap:
+            name: upperair-config

--- a/kubernetes/overlays/gsl-dev/upperair/deployment.yaml
+++ b/kubernetes/overlays/gsl-dev/upperair/deployment.yaml
@@ -7,13 +7,13 @@ spec:
     spec:
       containers:
         - name: upperair
-          # resources:
-          #   requests:
-          #     memory: "2Gi"
-          #     cpu: "1"
-          #   limits:
-          #     memory: "4Gi"
-          #     cpu: "2"
+          resources:
+            requests:
+              memory: "2Gi"
+              cpu: "1"
+            limits:
+              memory: "8Gi"
+              cpu: "4"
           envFrom:
             - secretRef:
                 name: upperair-secret

--- a/kubernetes/overlays/gsl-dev/upperair/kustomization.yaml
+++ b/kubernetes/overlays/gsl-dev/upperair/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - ../../../base/upperair
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: ghcr.io/noaa-gsl/mats/development/upperair
+    newTag: development 
+
+configMapGenerator:
+  - name: upperair-config
+    files:
+      - settings.json # Should mirror the appropriate settings.json file in mats-settings
+
+secretGenerator:
+  - name: upperair-secret
+    envs:
+      - .env # Should contain mongo_url, root_url, and delay

--- a/kubernetes/overlays/local/anomalycor/deployment.yaml
+++ b/kubernetes/overlays/local/anomalycor/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: anomalycor
+spec:
+  template:
+    spec:
+      containers:
+        - name: anomalycor
+          # resources:
+          #   requests:
+          #     memory: "2Gi"
+          #     cpu: "1"
+          #   limits:
+          #     memory: "4Gi"
+          #     cpu: "2"
+          envFrom:
+            - secretRef:
+                name: anomalycor-secret
+          volumeMounts:
+            - name: anomalycor-settings-file
+              mountPath: /usr/app/settings/anomalycor/settings.json
+              subPath: settings.json
+              readOnly: true
+      volumes:
+        - name: anomalycor-settings-file
+          configMap:
+            name: anomalycor-config

--- a/kubernetes/overlays/local/anomalycor/kustomization.yaml
+++ b/kubernetes/overlays/local/anomalycor/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - ../../../base/anomalycor
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: ghcr.io/noaa-gsl/mats/development/anomalycor
+    newTag: development 
+
+configMapGenerator:
+  - name: anomalycor-config
+    files:
+      - settings.json # Should mirror the appropriate settings.json file in mats-settings
+
+secretGenerator:
+  - name: anomalycor-secret
+    envs:
+      - .env # Should contain mongo_url, root_url, and delay

--- a/kubernetes/overlays/local/cb-ceiling/deployment.yaml
+++ b/kubernetes/overlays/local/cb-ceiling/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cb-ceiling
+spec:
+  template:
+    spec:
+      containers:
+        - name: cb-ceiling
+          # resources:
+          #   requests:
+          #     memory: "2Gi"
+          #     cpu: "1"
+          #   limits:
+          #     memory: "4Gi"
+          #     cpu: "2"
+          envFrom:
+            - secretRef:
+                name: cb-ceiling-secret
+          volumeMounts:
+            - name: cb-ceiling-settings-file
+              mountPath: /usr/app/settings/cb-ceiling/settings.json
+              subPath: settings.json
+              readOnly: true
+      volumes:
+        - name: cb-ceiling-settings-file
+          configMap:
+            name: cb-ceiling-config

--- a/kubernetes/overlays/local/cb-ceiling/kustomization.yaml
+++ b/kubernetes/overlays/local/cb-ceiling/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - ../../../base/cb-ceiling
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: ghcr.io/noaa-gsl/mats/development/cb-ceiling
+    newTag: development 
+
+configMapGenerator:
+  - name: cb-ceiling-config
+    files:
+      - settings.json # Should mirror the appropriate settings.json file in mats-settings
+
+secretGenerator:
+  - name: cb-ceiling-secret
+    envs:
+      - .env # Should contain mongo_url, root_url, and delay

--- a/kubernetes/overlays/local/ceil-vis/deployment.yaml
+++ b/kubernetes/overlays/local/ceil-vis/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ceil-vis
+spec:
+  template:
+    spec:
+      containers:
+        - name: ceil-vis
+          # resources:
+          #   requests:
+          #     memory: "2Gi"
+          #     cpu: "1"
+          #   limits:
+          #     memory: "4Gi"
+          #     cpu: "2"
+          envFrom:
+            - secretRef:
+                name: ceil-vis-secret
+          volumeMounts:
+            - name: ceil-vis-settings-file
+              mountPath: /usr/app/settings/ceil-vis/settings.json
+              subPath: settings.json
+              readOnly: true
+      volumes:
+        - name: ceil-vis-settings-file
+          configMap:
+            name: ceil-vis-config

--- a/kubernetes/overlays/local/ceil-vis/kustomization.yaml
+++ b/kubernetes/overlays/local/ceil-vis/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - ../../../base/ceil-vis
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: ghcr.io/noaa-gsl/mats/development/ceil-vis
+    newTag: development 
+
+configMapGenerator:
+  - name: ceil-vis-config
+    files:
+      - settings.json # Should mirror the appropriate settings.json file in mats-settings
+
+secretGenerator:
+  - name: ceil-vis-secret
+    envs:
+      - .env # Should contain mongo_url, root_url, and delay

--- a/kubernetes/overlays/local/ceil-vis15/deployment.yaml
+++ b/kubernetes/overlays/local/ceil-vis15/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ceil-vis15
+spec:
+  template:
+    spec:
+      containers:
+        - name: ceil-vis15
+          # resources:
+          #   requests:
+          #     memory: "2Gi"
+          #     cpu: "1"
+          #   limits:
+          #     memory: "4Gi"
+          #     cpu: "2"
+          envFrom:
+            - secretRef:
+                name: ceil-vis15-secret
+          volumeMounts:
+            - name: ceil-vis15-settings-file
+              mountPath: /usr/app/settings/ceil-vis15/settings.json
+              subPath: settings.json
+              readOnly: true
+      volumes:
+        - name: ceil-vis15-settings-file
+          configMap:
+            name: ceil-vis15-config

--- a/kubernetes/overlays/local/ceil-vis15/kustomization.yaml
+++ b/kubernetes/overlays/local/ceil-vis15/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - ../../../base/ceil-vis15
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: ghcr.io/noaa-gsl/mats/development/ceil-vis15
+    newTag: development 
+
+configMapGenerator:
+  - name: ceil-vis15-config
+    files:
+      - settings.json # Should mirror the appropriate settings.json file in mats-settings
+
+secretGenerator:
+  - name: ceil-vis15-secret
+    envs:
+      - .env # Should contain mongo_url, root_url, and delay

--- a/kubernetes/overlays/local/ingress.yaml
+++ b/kubernetes/overlays/local/ingress.yaml
@@ -51,3 +51,59 @@ spec:
                 name: landuse
                 port:
                   number: 80
+          - path: /precipaccum
+            pathType: Prefix
+            backend:
+              service:
+                name: precipaccum
+                port:
+                  number: 80
+          - path: /precipgauge
+            pathType: Prefix
+            backend:
+              service:
+                name: precipgauge
+                port:
+                  number: 80
+          - path: /precipitation1hr
+            pathType: Prefix
+            backend:
+              service:
+                name: precipitation1hr
+                port:
+                  number: 80
+          - path: /ptype
+            pathType: Prefix
+            backend:
+              service:
+                name: ptype
+                port:
+                  number: 80
+          - path: /radar
+            pathType: Prefix
+            backend:
+              service:
+                name: radar
+                port:
+                  number: 80
+          - path: /surface
+            pathType: Prefix
+            backend:
+              service:
+                name: surface
+                port:
+                  number: 80
+          - path: /surfrad
+            pathType: Prefix
+            backend:
+              service:
+                name: surfrad
+                port:
+                  number: 80
+          - path: /upperair
+            pathType: Prefix
+            backend:
+              service:
+                name: upperair
+                port:
+                  number: 80

--- a/kubernetes/overlays/local/ingress.yaml
+++ b/kubernetes/overlays/local/ingress.yaml
@@ -16,3 +16,10 @@ spec:
                 name: scorecard
                 port:
                   number: 80
+          - path: /anomalycor
+            pathType: Prefix
+            backend:
+              service:
+                name: anomalycor
+                port:
+                  number: 80

--- a/kubernetes/overlays/local/ingress.yaml
+++ b/kubernetes/overlays/local/ingress.yaml
@@ -23,3 +23,31 @@ spec:
                 name: anomalycor
                 port:
                   number: 80
+          - path: /cb-ceiling
+            pathType: Prefix
+            backend:
+              service:
+                name: cb-ceiling
+                port:
+                  number: 80
+          - path: /ceil-vis
+            pathType: Prefix
+            backend:
+              service:
+                name: ceil-vis
+                port:
+                  number: 80
+          - path: /ceil-vis15
+            pathType: Prefix
+            backend:
+              service:
+                name: ceil-vis15
+                port:
+                  number: 80
+          - path: /landuse
+            pathType: Prefix
+            backend:
+              service:
+                name: landuse
+                port:
+                  number: 80

--- a/kubernetes/overlays/local/kustomization.yaml
+++ b/kubernetes/overlays/local/kustomization.yaml
@@ -4,7 +4,15 @@ resources:
   - ceil-vis
   - ceil-vis15
   - landuse
+  - precipAccum
+  - precipGauge
+  - precipitation1hr
+  - ptype
+  - radar
   - scorecard
+  - surface
+  - surfrad
+  - upperair
   - mongo
   - ingress.yaml
 commonLabels:

--- a/kubernetes/overlays/local/kustomization.yaml
+++ b/kubernetes/overlays/local/kustomization.yaml
@@ -1,5 +1,9 @@
 resources:
   - anomalycor
+  - cb-ceiling
+  - ceil-vis
+  - ceil-vis15
+  - landuse
   - scorecard
   - mongo
   - ingress.yaml

--- a/kubernetes/overlays/local/kustomization.yaml
+++ b/kubernetes/overlays/local/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+  - anomalycor
   - scorecard
   - mongo
   - ingress.yaml

--- a/kubernetes/overlays/local/landuse/deployment.yaml
+++ b/kubernetes/overlays/local/landuse/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: landuse
+spec:
+  template:
+    spec:
+      containers:
+        - name: landuse
+          # resources:
+          #   requests:
+          #     memory: "2Gi"
+          #     cpu: "1"
+          #   limits:
+          #     memory: "4Gi"
+          #     cpu: "2"
+          envFrom:
+            - secretRef:
+                name: landuse-secret
+          volumeMounts:
+            - name: landuse-settings-file
+              mountPath: /usr/app/settings/landuse/settings.json
+              subPath: settings.json
+              readOnly: true
+      volumes:
+        - name: landuse-settings-file
+          configMap:
+            name: landuse-config

--- a/kubernetes/overlays/local/landuse/kustomization.yaml
+++ b/kubernetes/overlays/local/landuse/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - ../../../base/landuse
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: ghcr.io/noaa-gsl/mats/development/landuse
+    newTag: development 
+
+configMapGenerator:
+  - name: landuse-config
+    files:
+      - settings.json # Should mirror the appropriate settings.json file in mats-settings
+
+secretGenerator:
+  - name: landuse-secret
+    envs:
+      - .env # Should contain mongo_url, root_url, and delay

--- a/kubernetes/overlays/local/precipAccum/deployment.yaml
+++ b/kubernetes/overlays/local/precipAccum/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: precipaccum
+spec:
+  template:
+    spec:
+      containers:
+        - name: precipaccum
+          # resources:
+          #   requests:
+          #     memory: "2Gi"
+          #     cpu: "1"
+          #   limits:
+          #     memory: "4Gi"
+          #     cpu: "2"
+          envFrom:
+            - secretRef:
+                name: precipaccum-secret
+          volumeMounts:
+            - name: precipaccum-settings-file
+              mountPath: /usr/app/settings/precipaccum/settings.json
+              subPath: settings.json
+              readOnly: true
+      volumes:
+        - name: precipaccum-settings-file
+          configMap:
+            name: precipaccum-config

--- a/kubernetes/overlays/local/precipAccum/kustomization.yaml
+++ b/kubernetes/overlays/local/precipAccum/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - ../../../base/precipAccum
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: ghcr.io/noaa-gsl/mats/development/precipaccum
+    newTag: development 
+
+configMapGenerator:
+  - name: precipaccum-config
+    files:
+      - settings.json # Should mirror the appropriate settings.json file in mats-settings
+
+secretGenerator:
+  - name: precipaccum-secret
+    envs:
+      - .env # Should contain mongo_url, root_url, and delay

--- a/kubernetes/overlays/local/precipGauge/deployment.yaml
+++ b/kubernetes/overlays/local/precipGauge/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: precipgauge
+spec:
+  template:
+    spec:
+      containers:
+        - name: precipgauge
+          # resources:
+          #   requests:
+          #     memory: "2Gi"
+          #     cpu: "1"
+          #   limits:
+          #     memory: "4Gi"
+          #     cpu: "2"
+          envFrom:
+            - secretRef:
+                name: precipgauge-secret
+          volumeMounts:
+            - name: precipgauge-settings-file
+              mountPath: /usr/app/settings/precipgauge/settings.json
+              subPath: settings.json
+              readOnly: true
+      volumes:
+        - name: precipgauge-settings-file
+          configMap:
+            name: precipgauge-config

--- a/kubernetes/overlays/local/precipGauge/kustomization.yaml
+++ b/kubernetes/overlays/local/precipGauge/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - ../../../base/precipgauge
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: ghcr.io/noaa-gsl/mats/development/precipgauge
+    newTag: development 
+
+configMapGenerator:
+  - name: precipgauge-config
+    files:
+      - settings.json # Should mirror the appropriate settings.json file in mats-settings
+
+secretGenerator:
+  - name: precipgauge-secret
+    envs:
+      - .env # Should contain mongo_url, root_url, and delay

--- a/kubernetes/overlays/local/precipitation1hr/deployment.yaml
+++ b/kubernetes/overlays/local/precipitation1hr/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: precipitation1hr
+spec:
+  template:
+    spec:
+      containers:
+        - name: precipitation1hr
+          # resources:
+          #   requests:
+          #     memory: "2Gi"
+          #     cpu: "1"
+          #   limits:
+          #     memory: "4Gi"
+          #     cpu: "2"
+          envFrom:
+            - secretRef:
+                name: precipitation1hr-secret
+          volumeMounts:
+            - name: precipitation1hr-settings-file
+              mountPath: /usr/app/settings/precipitation1hr/settings.json
+              subPath: settings.json
+              readOnly: true
+      volumes:
+        - name: precipitation1hr-settings-file
+          configMap:
+            name: precipitation1hr-config

--- a/kubernetes/overlays/local/precipitation1hr/kustomization.yaml
+++ b/kubernetes/overlays/local/precipitation1hr/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - ../../../base/precipitation1hr
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: ghcr.io/noaa-gsl/mats/development/precipitation1hr
+    newTag: development 
+
+configMapGenerator:
+  - name: precipitation1hr-config
+    files:
+      - settings.json # Should mirror the appropriate settings.json file in mats-settings
+
+secretGenerator:
+  - name: precipitation1hr-secret
+    envs:
+      - .env # Should contain mongo_url, root_url, and delay

--- a/kubernetes/overlays/local/ptype/deployment.yaml
+++ b/kubernetes/overlays/local/ptype/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ptype
+spec:
+  template:
+    spec:
+      containers:
+        - name: ptype
+          # resources:
+          #   requests:
+          #     memory: "2Gi"
+          #     cpu: "1"
+          #   limits:
+          #     memory: "4Gi"
+          #     cpu: "2"
+          envFrom:
+            - secretRef:
+                name: ptype-secret
+          volumeMounts:
+            - name: ptype-settings-file
+              mountPath: /usr/app/settings/ptype/settings.json
+              subPath: settings.json
+              readOnly: true
+      volumes:
+        - name: ptype-settings-file
+          configMap:
+            name: ptype-config

--- a/kubernetes/overlays/local/ptype/kustomization.yaml
+++ b/kubernetes/overlays/local/ptype/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - ../../../base/ptype
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: ghcr.io/noaa-gsl/mats/development/ptype
+    newTag: development 
+
+configMapGenerator:
+  - name: ptype-config
+    files:
+      - settings.json # Should mirror the appropriate settings.json file in mats-settings
+
+secretGenerator:
+  - name: ptype-secret
+    envs:
+      - .env # Should contain mongo_url, root_url, and delay

--- a/kubernetes/overlays/local/radar/deployment.yaml
+++ b/kubernetes/overlays/local/radar/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: radar
+spec:
+  template:
+    spec:
+      containers:
+        - name: radar
+          # resources:
+          #   requests:
+          #     memory: "2Gi"
+          #     cpu: "1"
+          #   limits:
+          #     memory: "4Gi"
+          #     cpu: "2"
+          envFrom:
+            - secretRef:
+                name: radar-secret
+          volumeMounts:
+            - name: radar-settings-file
+              mountPath: /usr/app/settings/radar/settings.json
+              subPath: settings.json
+              readOnly: true
+      volumes:
+        - name: radar-settings-file
+          configMap:
+            name: radar-config

--- a/kubernetes/overlays/local/radar/kustomization.yaml
+++ b/kubernetes/overlays/local/radar/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - ../../../base/radar
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: ghcr.io/noaa-gsl/mats/development/radar
+    newTag: development 
+
+configMapGenerator:
+  - name: radar-config
+    files:
+      - settings.json # Should mirror the appropriate settings.json file in mats-settings
+
+secretGenerator:
+  - name: radar-secret
+    envs:
+      - .env # Should contain mongo_url, root_url, and delay

--- a/kubernetes/overlays/local/surface/deployment.yaml
+++ b/kubernetes/overlays/local/surface/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: surface
+spec:
+  template:
+    spec:
+      containers:
+        - name: surface
+          # resources:
+          #   requests:
+          #     memory: "2Gi"
+          #     cpu: "1"
+          #   limits:
+          #     memory: "4Gi"
+          #     cpu: "2"
+          envFrom:
+            - secretRef:
+                name: surface-secret
+          volumeMounts:
+            - name: surface-settings-file
+              mountPath: /usr/app/settings/surface/settings.json
+              subPath: settings.json
+              readOnly: true
+      volumes:
+        - name: surface-settings-file
+          configMap:
+            name: surface-config

--- a/kubernetes/overlays/local/surface/kustomization.yaml
+++ b/kubernetes/overlays/local/surface/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - ../../../base/surface
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: ghcr.io/noaa-gsl/mats/development/surface
+    newTag: development 
+
+configMapGenerator:
+  - name: surface-config
+    files:
+      - settings.json # Should mirror the appropriate settings.json file in mats-settings
+
+secretGenerator:
+  - name: surface-secret
+    envs:
+      - .env # Should contain mongo_url, root_url, and delay

--- a/kubernetes/overlays/local/surfrad/deployment.yaml
+++ b/kubernetes/overlays/local/surfrad/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: surfrad
+spec:
+  template:
+    spec:
+      containers:
+        - name: surfrad
+          # resources:
+          #   requests:
+          #     memory: "2Gi"
+          #     cpu: "1"
+          #   limits:
+          #     memory: "4Gi"
+          #     cpu: "2"
+          envFrom:
+            - secretRef:
+                name: surfrad-secret
+          volumeMounts:
+            - name: surfrad-settings-file
+              mountPath: /usr/app/settings/surfrad/settings.json
+              subPath: settings.json
+              readOnly: true
+      volumes:
+        - name: surfrad-settings-file
+          configMap:
+            name: surfrad-config

--- a/kubernetes/overlays/local/surfrad/kustomization.yaml
+++ b/kubernetes/overlays/local/surfrad/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - ../../../base/surfrad
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: ghcr.io/noaa-gsl/mats/development/surfrad
+    newTag: development 
+
+configMapGenerator:
+  - name: surfrad-config
+    files:
+      - settings.json # Should mirror the appropriate settings.json file in mats-settings
+
+secretGenerator:
+  - name: surfrad-secret
+    envs:
+      - .env # Should contain mongo_url, root_url, and delay

--- a/kubernetes/overlays/local/upperair/deployment.yaml
+++ b/kubernetes/overlays/local/upperair/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: upperair
+spec:
+  template:
+    spec:
+      containers:
+        - name: upperair
+          # resources:
+          #   requests:
+          #     memory: "2Gi"
+          #     cpu: "1"
+          #   limits:
+          #     memory: "4Gi"
+          #     cpu: "2"
+          envFrom:
+            - secretRef:
+                name: upperair-secret
+          volumeMounts:
+            - name: upperair-settings-file
+              mountPath: /usr/app/settings/upperair/settings.json
+              subPath: settings.json
+              readOnly: true
+      volumes:
+        - name: upperair-settings-file
+          configMap:
+            name: upperair-config

--- a/kubernetes/overlays/local/upperair/kustomization.yaml
+++ b/kubernetes/overlays/local/upperair/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - ../../../base/upperair
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: ghcr.io/noaa-gsl/mats/development/upperair
+    newTag: development 
+
+configMapGenerator:
+  - name: upperair-config
+    files:
+      - settings.json # Should mirror the appropriate settings.json file in mats-settings
+
+secretGenerator:
+  - name: upperair-secret
+    envs:
+      - .env # Should contain mongo_url, root_url, and delay


### PR DESCRIPTION
This is the last PR in a 3-part "[stacked PR](https://www.michaelagreiler.com/stacked-pull-requests/)".

This PR creates deployments and services for the rest of the MATS apps in [Kustomize overlays](https://kubectl.docs.kubernetes.io/guides/introduction/kustomize/#2-create-variants-using-overlays) for both a local Rancher Desktop cluster and the GSL dev cluster and then exposes them through an ingress. I also set some resource limits on the deployments in the dev cluster as I was noticing that a number of our deployments were getting evicted by other non-MATS deployments in the cluster. I gave the mongo deployment [strict resource limits so it would get a "Guaranteed" QoS level](https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/) from the k8s scheduler.

This PR relates to issue https://github.com/NOAA-GSL/MATS/issues/764. The first PR in the stack is https://github.com/NOAA-GSL/MATS/pull/881.