### PR TITLE
K8s PR 4 - Increase monogo pvc size

### DIFF
--- a/kubernetes/base/mongo/pvc.yaml
+++ b/kubernetes/base/mongo/pvc.yaml
@@ -9,4 +9,4 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 1Gi
+      storage: 10Gi


### PR DESCRIPTION
Randy mentioned that we typically use 10 GB of space for mongo. Having this extra space will be especially important for the scorecard app.

Closes #890 