### PR TITLE
Switch to a Debian-based image for production 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 90
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 30
     permissions:
       actions: read
       contents: read

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN apk --no-cache add \
     bash \
     g++ \
     make \
+    cmake \
     python3
 
 # Copy in build scripts & entrypoint

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,9 @@ COPY --from=meteor-builder /opt/bundle $APP_BUNDLE_FOLDER/
 # Build the native dependencies
 # NOTE - the randyp_mats-common atmosphere package pulls in a native npm couchbase dependency
 # so we need to force an npm rebuild in the node_modules directory there as well
-RUN bash $SCRIPTS_FOLDER/build-meteor-npm-dependencies.sh
+RUN bash $SCRIPTS_FOLDER/build-meteor-npm-dependencies.sh --build-from-source \
+&& cd $APP_BUNDLE_FOLDER/bundle/programs/server/npm/node_modules/meteor/randyp_mats-common \
+&& npm rebuild --build-from-source
 
 
 # Use the specific version of Node expected by your Meteor release, per https://docs.meteor.com/changelog.html

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
     bash \
     ca-certificates \
-    mariadb-client \
     python3 \
     python3-numpy \
     python3-pip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,11 +54,10 @@ ENV VERSION=${BUILDVER}
 ENV BRANCH=${COMMITBRANCH}
 ENV COMMIT=${COMMITSHA}
 
-# Copy in helper scripts with the built and installed dependencies from the previous image
+# Copy in helper scripts from the previous image
 COPY --from=meteor-builder ${SCRIPTS_FOLDER} ${SCRIPTS_FOLDER}/
 
-# Copy in app bundle with the built and installed dependencies from the previous image
-# COPY --from=meteor-builder ${APP_BUNDLE_FOLDER} ${APP_BUNDLE_FOLDER}/
+# Copy in app bundle from the previous image
 COPY --from=meteor-builder /opt/bundle ${APP_BUNDLE_FOLDER}/
 
 # We want to use our own launcher script

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN apk --no-cache add \
     g++ \
     make \
     cmake \
+    linux-headers \
     python3
 
 # Copy in build scripts & entrypoint


### PR DESCRIPTION
Switch our Dockerfile to use `node:14-bullseye-slim` instead of `node:14-alpine` for our production image. Switching to a Debian-based OS makes CI builds much quicker (builds take ~15 min instead of 90+ min) and removes a whole host of libc/musl compatibility issues that come about from using the Debian-based `meteor-base` image and copying artifacts into an Alpine-based production image. 

Additionally, I took the opportunity to:
- add a step at the end of our Dockerfile to pull in OS updates to mitigate OS vulnerabilities. 
- eliminate the `mariadb` package. This will save space and cut down on vulnerabilities. MATS uses pure-Python and pure-JS MySQL dependencies and has no need for a native mysql/mariadb package to be installed. Additionally, we didn't need to have a whole mariadb database server installed in our Docker images.