### PR TITLE
Add a Kustomization overlay for the prod cluster

### DIFF
--- a/kubernetes/overlays/gsl-prod/anomalycor/deployment.yaml
+++ b/kubernetes/overlays/gsl-prod/anomalycor/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: anomalycor
+spec:
+  template:
+    spec:
+      containers:
+        - name: anomalycor
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: "0.25"
+            limits:
+              memory: "8Gi"
+              cpu: "4"
+          envFrom:
+            - secretRef:
+                name: anomalycor-secret
+          volumeMounts:
+            - name: anomalycor-settings-file
+              mountPath: /usr/app/settings/anomalycor/settings.json
+              subPath: settings.json
+              readOnly: true
+          imagePullPolicy: Always  # Since we track a long-lived tag
+      imagePullSecrets:
+        - name: mats-ghcr
+      volumes:
+        - name: anomalycor-settings-file
+          configMap:
+            name: anomalycor-config

--- a/kubernetes/overlays/gsl-prod/anomalycor/kustomization.yaml
+++ b/kubernetes/overlays/gsl-prod/anomalycor/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - ../../../base/anomalycor
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: ghcr.io/noaa-gsl/mats/development/anomalycor
+    newTag: development 
+
+configMapGenerator:
+  - name: anomalycor-config
+    files:
+      - settings.json # Should mirror the appropriate settings.json file in mats-settings
+
+secretGenerator:
+  - name: anomalycor-secret
+    envs:
+      - .env # Should contain mongo_url, root_url, and delay

--- a/kubernetes/overlays/gsl-prod/cb-ceiling/deployment.yaml
+++ b/kubernetes/overlays/gsl-prod/cb-ceiling/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cb-ceiling
+spec:
+  template:
+    spec:
+      containers:
+        - name: cb-ceiling
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: "0.25"
+            limits:
+              memory: "8Gi"
+              cpu: "4"
+          envFrom:
+            - secretRef:
+                name: cb-ceiling-secret
+          volumeMounts:
+            - name: cb-ceiling-settings-file
+              mountPath: /usr/app/settings/cb-ceiling/settings.json
+              subPath: settings.json
+              readOnly: true
+          imagePullPolicy: Always  # Since we track a long-lived tag
+      imagePullSecrets:
+        - name: mats-ghcr
+      volumes:
+        - name: cb-ceiling-settings-file
+          configMap:
+            name: cb-ceiling-config

--- a/kubernetes/overlays/gsl-prod/cb-ceiling/kustomization.yaml
+++ b/kubernetes/overlays/gsl-prod/cb-ceiling/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - ../../../base/cb-ceiling
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: ghcr.io/noaa-gsl/mats/development/cb-ceiling
+    newTag: development 
+
+configMapGenerator:
+  - name: cb-ceiling-config
+    files:
+      - settings.json # Should mirror the appropriate settings.json file in mats-settings
+
+secretGenerator:
+  - name: cb-ceiling-secret
+    envs:
+      - .env # Should contain mongo_url, root_url, and delay

--- a/kubernetes/overlays/gsl-prod/ceil-vis/deployment.yaml
+++ b/kubernetes/overlays/gsl-prod/ceil-vis/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ceil-vis
+spec:
+  template:
+    spec:
+      containers:
+        - name: ceil-vis
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: "0.25"
+            limits:
+              memory: "8Gi"
+              cpu: "4"
+          envFrom:
+            - secretRef:
+                name: ceil-vis-secret
+          volumeMounts:
+            - name: ceil-vis-settings-file
+              mountPath: /usr/app/settings/ceil-vis/settings.json
+              subPath: settings.json
+              readOnly: true
+          imagePullPolicy: Always  # Since we track a long-lived tag
+      imagePullSecrets:
+        - name: mats-ghcr
+      volumes:
+        - name: ceil-vis-settings-file
+          configMap:
+            name: ceil-vis-config

--- a/kubernetes/overlays/gsl-prod/ceil-vis/kustomization.yaml
+++ b/kubernetes/overlays/gsl-prod/ceil-vis/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - ../../../base/ceil-vis
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: ghcr.io/noaa-gsl/mats/development/ceil-vis
+    newTag: development 
+
+configMapGenerator:
+  - name: ceil-vis-config
+    files:
+      - settings.json # Should mirror the appropriate settings.json file in mats-settings
+
+secretGenerator:
+  - name: ceil-vis-secret
+    envs:
+      - .env # Should contain mongo_url, root_url, and delay

--- a/kubernetes/overlays/gsl-prod/ceil-vis15/deployment.yaml
+++ b/kubernetes/overlays/gsl-prod/ceil-vis15/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ceil-vis15
+spec:
+  template:
+    spec:
+      containers:
+        - name: ceil-vis15
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: "0.25"
+            limits:
+              memory: "8Gi"
+              cpu: "4"
+          envFrom:
+            - secretRef:
+                name: ceil-vis15-secret
+          volumeMounts:
+            - name: ceil-vis15-settings-file
+              mountPath: /usr/app/settings/ceil-vis15/settings.json
+              subPath: settings.json
+              readOnly: true
+          imagePullPolicy: Always  # Since we track a long-lived tag
+      imagePullSecrets:
+        - name: mats-ghcr
+      volumes:
+        - name: ceil-vis15-settings-file
+          configMap:
+            name: ceil-vis15-config

--- a/kubernetes/overlays/gsl-prod/ceil-vis15/kustomization.yaml
+++ b/kubernetes/overlays/gsl-prod/ceil-vis15/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - ../../../base/ceil-vis15
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: ghcr.io/noaa-gsl/mats/development/ceil-vis15
+    newTag: development 
+
+configMapGenerator:
+  - name: ceil-vis15-config
+    files:
+      - settings.json # Should mirror the appropriate settings.json file in mats-settings
+
+secretGenerator:
+  - name: ceil-vis15-secret
+    envs:
+      - .env # Should contain mongo_url, root_url, and delay

--- a/kubernetes/overlays/gsl-prod/ingress.yaml
+++ b/kubernetes/overlays/gsl-prod/ingress.yaml
@@ -1,0 +1,111 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    # Omit the rewrite-target annotation as it causes problems with Meteor's ROOT_URL
+    nginx.ingress.kubernetes.io/use-regex: "true"
+  name: mats
+  namespace: mats-dev
+spec:
+  rules:
+    - host: apps-prod.gsd.esrl.noaa.gov
+      http:
+        paths:
+          - path: /mats-dev/scorecard
+            pathType: Prefix
+            backend:
+              service:
+                name: scorecard
+                port:
+                  name: http
+          - path: /mats-dev/anomalycor
+            pathType: Prefix
+            backend:
+              service:
+                name: anomalycor
+                port:
+                  name: http
+          - path: /mats-dev/cb-ceiling
+            pathType: Prefix
+            backend:
+              service:
+                name: cb-ceiling
+                port:
+                  number: 80
+          - path: /mats-dev/ceil-vis
+            pathType: Prefix
+            backend:
+              service:
+                name: ceil-vis
+                port:
+                  number: 80
+          - path: /mats-dev/ceil-vis15
+            pathType: Prefix
+            backend:
+              service:
+                name: ceil-vis15
+                port:
+                  number: 80
+          - path: /mats-dev/landuse
+            pathType: Prefix
+            backend:
+              service:
+                name: landuse
+                port:
+                  number: 80
+          - path: /mats-dev/precipaccum
+            pathType: Prefix
+            backend:
+              service:
+                name: precipaccum
+                port:
+                  number: 80
+          - path: /mats-dev/precipgauge
+            pathType: Prefix
+            backend:
+              service:
+                name: precipgauge
+                port:
+                  number: 80
+          - path: /mats-dev/precipitation1hr
+            pathType: Prefix
+            backend:
+              service:
+                name: precipitation1hr
+                port:
+                  number: 80
+          - path: /mats-dev/ptype
+            pathType: Prefix
+            backend:
+              service:
+                name: ptype
+                port:
+                  number: 80
+          - path: /mats-dev/radar
+            pathType: Prefix
+            backend:
+              service:
+                name: radar
+                port:
+                  number: 80
+          - path: /mats-dev/surface
+            pathType: Prefix
+            backend:
+              service:
+                name: surface
+                port:
+                  number: 80
+          - path: /mats-dev/surfrad
+            pathType: Prefix
+            backend:
+              service:
+                name: surfrad
+                port:
+                  number: 80
+          - path: /mats-dev/upperair
+            pathType: Prefix
+            backend:
+              service:
+                name: upperair
+                port:
+                  number: 80

--- a/kubernetes/overlays/gsl-prod/kustomization.yaml
+++ b/kubernetes/overlays/gsl-prod/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - anomalycor
+  - cb-ceiling
+  - ceil-vis
+  - ceil-vis15
+  - landuse
+  - precipAccum
+  - precipGauge
+  - precipitation1hr
+  - ptype
+  - radar
+  - scorecard
+  - surface
+  - surfrad
+  - upperair
+  - mongo
+  - ingress.yaml
+commonLabels:
+  environment: prod

--- a/kubernetes/overlays/gsl-prod/landuse/deployment.yaml
+++ b/kubernetes/overlays/gsl-prod/landuse/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: landuse
+spec:
+  template:
+    spec:
+      containers:
+        - name: landuse
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: "0.25"
+            limits:
+              memory: "8Gi"
+              cpu: "4"
+          envFrom:
+            - secretRef:
+                name: landuse-secret
+          volumeMounts:
+            - name: landuse-settings-file
+              mountPath: /usr/app/settings/landuse/settings.json
+              subPath: settings.json
+              readOnly: true
+          imagePullPolicy: Always  # Since we track a long-lived tag
+      imagePullSecrets:
+        - name: mats-ghcr
+      volumes:
+        - name: landuse-settings-file
+          configMap:
+            name: landuse-config

--- a/kubernetes/overlays/gsl-prod/landuse/kustomization.yaml
+++ b/kubernetes/overlays/gsl-prod/landuse/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - ../../../base/landuse
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: ghcr.io/noaa-gsl/mats/development/landuse
+    newTag: development 
+
+configMapGenerator:
+  - name: landuse-config
+    files:
+      - settings.json # Should mirror the appropriate settings.json file in mats-settings
+
+secretGenerator:
+  - name: landuse-secret
+    envs:
+      - .env # Should contain mongo_url, root_url, and delay

--- a/kubernetes/overlays/gsl-prod/mongo/deployment.yaml
+++ b/kubernetes/overlays/gsl-prod/mongo/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mongodb
+spec:
+  template:
+    spec:
+      containers:
+        - name: mongodb
+          resources:
+            requests:
+              memory: "2Gi"
+              cpu: "1"
+            limits:
+              memory: "2Gi"
+              cpu: "1"
+          envFrom:
+            - secretRef:
+                name: mongo-secret
+          volumeMounts:
+            - name: mongo-config-file
+              mountPath: /etc/mongod.conf
+              readOnly: true
+      volumes:
+        - name: mongo-config-file
+          configMap:
+            name: mongo-config

--- a/kubernetes/overlays/gsl-prod/mongo/kustomization.yaml
+++ b/kubernetes/overlays/gsl-prod/mongo/kustomization.yaml
@@ -1,0 +1,15 @@
+resources:
+  - ../../../base/mongo
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+configMapGenerator:
+  - name: mongo-config
+    files:
+      - mongod.conf
+
+secretGenerator:
+  - name: mongo-secret
+    envs:
+    - .env.mongo.secret # Should contain user and password

--- a/kubernetes/overlays/gsl-prod/mongo/mongod.conf
+++ b/kubernetes/overlays/gsl-prod/mongo/mongod.conf
@@ -1,0 +1,14 @@
+systemLog:
+   destination: file
+   path: "/var/log/mongodb/mongod.log"
+   logAppend: true
+storage:
+   journal:
+      enabled: true
+processManagement:
+   fork: true
+net:
+   bindIp: 127.0.0.1
+   port: 27017
+setParameter:
+   enableLocalhostAuthBypass: false

--- a/kubernetes/overlays/gsl-prod/precipAccum/deployment.yaml
+++ b/kubernetes/overlays/gsl-prod/precipAccum/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: precipaccum
+spec:
+  template:
+    spec:
+      containers:
+        - name: precipaccum
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: "0.25"
+            limits:
+              memory: "8Gi"
+              cpu: "4"
+          envFrom:
+            - secretRef:
+                name: precipaccum-secret
+          volumeMounts:
+            - name: precipaccum-settings-file
+              mountPath: /usr/app/settings/precipAccum/settings.json
+              subPath: settings.json
+              readOnly: true
+          imagePullPolicy: Always  # Since we track a long-lived tag
+      imagePullSecrets:
+        - name: mats-ghcr
+      volumes:
+        - name: precipaccum-settings-file
+          configMap:
+            name: precipaccum-config

--- a/kubernetes/overlays/gsl-prod/precipAccum/kustomization.yaml
+++ b/kubernetes/overlays/gsl-prod/precipAccum/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - ../../../base/precipAccum
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: ghcr.io/noaa-gsl/mats/development/precipaccum
+    newTag: development 
+
+configMapGenerator:
+  - name: precipaccum-config
+    files:
+      - settings.json # Should mirror the appropriate settings.json file in mats-settings
+
+secretGenerator:
+  - name: precipaccum-secret
+    envs:
+      - .env # Should contain mongo_url, root_url, and delay

--- a/kubernetes/overlays/gsl-prod/precipGauge/deployment.yaml
+++ b/kubernetes/overlays/gsl-prod/precipGauge/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: precipgauge
+spec:
+  template:
+    spec:
+      containers:
+        - name: precipgauge
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: "0.25"
+            limits:
+              memory: "8Gi"
+              cpu: "4"
+          envFrom:
+            - secretRef:
+                name: precipgauge-secret
+          volumeMounts:
+            - name: precipgauge-settings-file
+              mountPath: /usr/app/settings/precipGauge/settings.json
+              subPath: settings.json
+              readOnly: true
+          imagePullPolicy: Always  # Since we track a long-lived tag
+      imagePullSecrets:
+        - name: mats-ghcr
+      volumes:
+        - name: precipgauge-settings-file
+          configMap:
+            name: precipgauge-config

--- a/kubernetes/overlays/gsl-prod/precipGauge/kustomization.yaml
+++ b/kubernetes/overlays/gsl-prod/precipGauge/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - ../../../base/precipgauge
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: ghcr.io/noaa-gsl/mats/development/precipgauge
+    newTag: development 
+
+configMapGenerator:
+  - name: precipgauge-config
+    files:
+      - settings.json # Should mirror the appropriate settings.json file in mats-settings
+
+secretGenerator:
+  - name: precipgauge-secret
+    envs:
+      - .env # Should contain mongo_url, root_url, and delay

--- a/kubernetes/overlays/gsl-prod/precipitation1hr/deployment.yaml
+++ b/kubernetes/overlays/gsl-prod/precipitation1hr/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: precipitation1hr
+spec:
+  template:
+    spec:
+      containers:
+        - name: precipitation1hr
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: "0.25"
+            limits:
+              memory: "8Gi"
+              cpu: "4"
+          envFrom:
+            - secretRef:
+                name: precipitation1hr-secret
+          volumeMounts:
+            - name: precipitation1hr-settings-file
+              mountPath: /usr/app/settings/precipitation1hr/settings.json
+              subPath: settings.json
+              readOnly: true
+          imagePullPolicy: Always  # Since we track a long-lived tag
+      imagePullSecrets:
+        - name: mats-ghcr
+      volumes:
+        - name: precipitation1hr-settings-file
+          configMap:
+            name: precipitation1hr-config

--- a/kubernetes/overlays/gsl-prod/precipitation1hr/kustomization.yaml
+++ b/kubernetes/overlays/gsl-prod/precipitation1hr/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - ../../../base/precipitation1hr
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: ghcr.io/noaa-gsl/mats/development/precipitation1hr
+    newTag: development 
+
+configMapGenerator:
+  - name: precipitation1hr-config
+    files:
+      - settings.json # Should mirror the appropriate settings.json file in mats-settings
+
+secretGenerator:
+  - name: precipitation1hr-secret
+    envs:
+      - .env # Should contain mongo_url, root_url, and delay

--- a/kubernetes/overlays/gsl-prod/ptype/deployment.yaml
+++ b/kubernetes/overlays/gsl-prod/ptype/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ptype
+spec:
+  template:
+    spec:
+      containers:
+        - name: ptype
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: "0.25"
+            limits:
+              memory: "8Gi"
+              cpu: "4"
+          envFrom:
+            - secretRef:
+                name: ptype-secret
+          volumeMounts:
+            - name: ptype-settings-file
+              mountPath: /usr/app/settings/ptype/settings.json
+              subPath: settings.json
+              readOnly: true
+          imagePullPolicy: Always  # Since we track a long-lived tag
+      imagePullSecrets:
+        - name: mats-ghcr
+      volumes:
+        - name: ptype-settings-file
+          configMap:
+            name: ptype-config

--- a/kubernetes/overlays/gsl-prod/ptype/kustomization.yaml
+++ b/kubernetes/overlays/gsl-prod/ptype/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - ../../../base/ptype
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: ghcr.io/noaa-gsl/mats/development/ptype
+    newTag: development 
+
+configMapGenerator:
+  - name: ptype-config
+    files:
+      - settings.json # Should mirror the appropriate settings.json file in mats-settings
+
+secretGenerator:
+  - name: ptype-secret
+    envs:
+      - .env # Should contain mongo_url, root_url, and delay

--- a/kubernetes/overlays/gsl-prod/radar/deployment.yaml
+++ b/kubernetes/overlays/gsl-prod/radar/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: radar
+spec:
+  template:
+    spec:
+      containers:
+        - name: radar
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: "0.25"
+            limits:
+              memory: "8Gi"
+              cpu: "4"
+          envFrom:
+            - secretRef:
+                name: radar-secret
+          volumeMounts:
+            - name: radar-settings-file
+              mountPath: /usr/app/settings/radar/settings.json
+              subPath: settings.json
+              readOnly: true
+          imagePullPolicy: Always  # Since we track a long-lived tag
+      imagePullSecrets:
+        - name: mats-ghcr
+      volumes:
+        - name: radar-settings-file
+          configMap:
+            name: radar-config

--- a/kubernetes/overlays/gsl-prod/radar/kustomization.yaml
+++ b/kubernetes/overlays/gsl-prod/radar/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - ../../../base/radar
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: ghcr.io/noaa-gsl/mats/development/radar
+    newTag: development 
+
+configMapGenerator:
+  - name: radar-config
+    files:
+      - settings.json # Should mirror the appropriate settings.json file in mats-settings
+
+secretGenerator:
+  - name: radar-secret
+    envs:
+      - .env # Should contain mongo_url, root_url, and delay

--- a/kubernetes/overlays/gsl-prod/scorecard/deployment.yaml
+++ b/kubernetes/overlays/gsl-prod/scorecard/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scorecard
+spec:
+  template:
+    spec:
+      containers:
+        - name: scorecard
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: "0.25"
+            limits:
+              memory: "8Gi"
+              cpu: "4"
+          envFrom:
+            - secretRef:
+                name: scorecard-secret
+          volumeMounts:
+            - name: scorecard-settings-file
+              mountPath: /usr/app/settings/scorecard/settings.json
+              subPath: settings.json
+              readOnly: true
+          imagePullPolicy: Always  # Since we track a long-lived tag
+      imagePullSecrets:
+        - name: mats-ghcr
+      volumes:
+        - name: scorecard-settings-file
+          configMap:
+            name: scorecard-config

--- a/kubernetes/overlays/gsl-prod/scorecard/kustomization.yaml
+++ b/kubernetes/overlays/gsl-prod/scorecard/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - ../../../base/scorecard
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: ghcr.io/noaa-gsl/mats/development/scorecard
+    newTag: development
+
+configMapGenerator:
+  - name: scorecard-config
+    files:
+      - settings.json # Should mirror the appropriate settings.json file in mats-settings
+
+secretGenerator:
+  - name: scorecard-secret
+    envs:
+      - .env # Should contain mongo_url, root_url, and delay

--- a/kubernetes/overlays/gsl-prod/surface/deployment.yaml
+++ b/kubernetes/overlays/gsl-prod/surface/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: surface
+spec:
+  template:
+    spec:
+      containers:
+        - name: surface
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: "0.25"
+            limits:
+              memory: "8Gi"
+              cpu: "4"
+          envFrom:
+            - secretRef:
+                name: surface-secret
+          volumeMounts:
+            - name: surface-settings-file
+              mountPath: /usr/app/settings/surface/settings.json
+              subPath: settings.json
+              readOnly: true
+          imagePullPolicy: Always  # Since we track a long-lived tag
+      imagePullSecrets:
+        - name: mats-ghcr
+      volumes:
+        - name: surface-settings-file
+          configMap:
+            name: surface-config

--- a/kubernetes/overlays/gsl-prod/surface/kustomization.yaml
+++ b/kubernetes/overlays/gsl-prod/surface/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - ../../../base/surface
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: ghcr.io/noaa-gsl/mats/development/surface
+    newTag: development 
+
+configMapGenerator:
+  - name: surface-config
+    files:
+      - settings.json # Should mirror the appropriate settings.json file in mats-settings
+
+secretGenerator:
+  - name: surface-secret
+    envs:
+      - .env # Should contain mongo_url, root_url, and delay

--- a/kubernetes/overlays/gsl-prod/surfrad/deployment.yaml
+++ b/kubernetes/overlays/gsl-prod/surfrad/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: surfrad
+spec:
+  template:
+    spec:
+      containers:
+        - name: surfrad
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: "0.25"
+            limits:
+              memory: "8Gi"
+              cpu: "4"
+          envFrom:
+            - secretRef:
+                name: surfrad-secret
+          volumeMounts:
+            - name: surfrad-settings-file
+              mountPath: /usr/app/settings/surfrad/settings.json
+              subPath: settings.json
+              readOnly: true
+          imagePullPolicy: Always  # Since we track a long-lived tag
+      imagePullSecrets:
+        - name: mats-ghcr
+      volumes:
+        - name: surfrad-settings-file
+          configMap:
+            name: surfrad-config

--- a/kubernetes/overlays/gsl-prod/surfrad/kustomization.yaml
+++ b/kubernetes/overlays/gsl-prod/surfrad/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - ../../../base/surfrad
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: ghcr.io/noaa-gsl/mats/development/surfrad
+    newTag: development 
+
+configMapGenerator:
+  - name: surfrad-config
+    files:
+      - settings.json # Should mirror the appropriate settings.json file in mats-settings
+
+secretGenerator:
+  - name: surfrad-secret
+    envs:
+      - .env # Should contain mongo_url, root_url, and delay

--- a/kubernetes/overlays/gsl-prod/upperair/deployment.yaml
+++ b/kubernetes/overlays/gsl-prod/upperair/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: upperair
+spec:
+  template:
+    spec:
+      containers:
+        - name: upperair
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: "0.25"
+            limits:
+              memory: "8Gi"
+              cpu: "4"
+          envFrom:
+            - secretRef:
+                name: upperair-secret
+          volumeMounts:
+            - name: upperair-settings-file
+              mountPath: /usr/app/settings/upperair/settings.json
+              subPath: settings.json
+              readOnly: true
+          imagePullPolicy: Always  # Since we track a long-lived tag
+      imagePullSecrets:
+        - name: mats-ghcr
+      volumes:
+        - name: upperair-settings-file
+          configMap:
+            name: upperair-config

--- a/kubernetes/overlays/gsl-prod/upperair/kustomization.yaml
+++ b/kubernetes/overlays/gsl-prod/upperair/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - ../../../base/upperair
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: ghcr.io/noaa-gsl/mats/development/upperair
+    newTag: development 
+
+configMapGenerator:
+  - name: upperair-config
+    files:
+      - settings.json # Should mirror the appropriate settings.json file in mats-settings
+
+secretGenerator:
+  - name: upperair-secret
+    envs:
+      - .env # Should contain mongo_url, root_url, and delay


### PR DESCRIPTION
This PR copies our existing `gsl-dev` Kustomize overlay and updates the URLs for use in the `gsl-prod` cluster. I've deployed the application to the new cluster and tested that it is up. 