### PR TITLE
Split the Environment config into two options

### DIFF
--- a/home/README.md
+++ b/home/README.md
@@ -7,11 +7,13 @@ A home app for MATS & METexpress. Written in Go with the Gin framework.
 First, you'll need a settings file like so in `MATS/home`:
 
 `settings.json`:
+
 ```json
 {
     "config": {
-        "met_express": false,
-        "environment": "Development"
+        "is_met_express": false,
+        "is_production": false,
+        "environment_label": "Development"
     },
     "groups": [
     {

--- a/home/main.go
+++ b/home/main.go
@@ -12,8 +12,9 @@ import (
 
 type ConfigJSON struct {
 	Config struct {
-		METexpress  bool   `json:"met_express"`
-		Environment string `json:"environment"`
+		IsMETexpress     bool   `json:"is_met_express"`
+		IsProduction     bool   `json:"is_production"`
+		EnvironmentLabel string `json:"environment_label"`
 	} `json:"config"`
 	Groups []struct {
 		Name string `json:"name"`
@@ -78,9 +79,8 @@ func main() {
 func indexHandler(settings ConfigJSON) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		c.HTML(http.StatusOK, "index.html", gin.H{
-			"Environment": settings.Config.Environment,
-			"METexpress":  settings.Config.METexpress,
-			"Groups":      settings.Groups,
+			"Config": settings.Config,
+			"Groups": settings.Groups,
 		})
 	}
 }

--- a/home/templates/header.html
+++ b/home/templates/header.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <link rel="icon" href="favicon.svg" type="image/x-icon" />
-  {{ if .METexpress }}
+  {{ if .Config.IsMETexpress }}
   <title>METexpress</title>
   {{ else }}
   <title>MATS: Model Analysis Tool Suite</title>

--- a/home/templates/index.html
+++ b/home/templates/index.html
@@ -13,14 +13,14 @@
     <div id="main" class="container-fluid">
       {{ template "navbar.html" . }}
 
-      {{ if .METexpress }}
+      {{ if .Config.IsMETexpress }}
       {{ else }}
         {{ template "toggles.html" . }}
       {{ end }}
 
       {{ template "apps.html" . }}
 
-      {{ if .METexpress }}
+      {{ if .Config.IsMETexpress }}
         {{ template "metexpress-footer.html" . }}
       {{ else }}
         {{ template "mats-footer.html" . }}

--- a/home/templates/navbar.html
+++ b/home/templates/navbar.html
@@ -24,14 +24,15 @@
           src="img/noaa-logo-rgb-2022.svg"
           alt="NOAA Logo"
         />
-        {{ if .METexpress }}
+        {{ if .Config.IsMETexpress }}
         <span class="fs-2">METexpress</span>
         {{ else }}
         <span class="fs-2">Model Analysis Tool Suite (MATS)</span>
         {{ end }}
-        {{ if ne .Environment "Production"}}
-        <span class="fs-6">{{.Environment}} Server</span>
-        {{ else }} {{ end }}
+        {{ if .Config.EnvironmentLabel }}
+        <span class="fs-6">{{ .Config.EnvironmentLabel }} Server</span>
+        {{ else }}
+        {{ end }}
       </a>
       <!-- Collect the nav links, forms, and other content for toggling -->
       <!-- Create a navbar collection that's right justified -->

--- a/home/templates/toggles.html
+++ b/home/templates/toggles.html
@@ -32,7 +32,7 @@
       />
       <label class="btn btn-outline-secondary" for="btnradiometplus">METplus</label>
 
-      {{ if ne .Environment "Production"}}
+      {{ if not .Config.IsProduction }}
       <input
         type="radio"
         class="btn-check"


### PR DESCRIPTION
The "Environment" config option had two effects - it set the subtitle on the page if it was anything other than "Production" and also would show/hide the toggle for experimental GSL apps if it was set to "Production". This overloading was undesired and so I've created a new "EnvironmentLabel" option to control the subtitle in the UI and a "IsProduction" option to toggle show/hide behavior.