### PR TITLE
Add a configurable alert to convey shutdown info

### DIFF
--- a/home/README.md
+++ b/home/README.md
@@ -14,7 +14,6 @@ First, you'll need a settings file like so in `MATS/home`:
         "is_met_express": false,
         "is_production": false,
         "environment_label": "Development",
-        "display_alert": false,
         "alert_message": "Lorem ipsum dolor shutdown amet..."
     },
     "groups": [

--- a/home/README.md
+++ b/home/README.md
@@ -13,7 +13,9 @@ First, you'll need a settings file like so in `MATS/home`:
     "config": {
         "is_met_express": false,
         "is_production": false,
-        "environment_label": "Development"
+        "environment_label": "Development",
+        "display_alert": false,
+        "alert_message": "Lorem ipsum dolor shutdown amet..."
     },
     "groups": [
     {

--- a/home/main.go
+++ b/home/main.go
@@ -15,6 +15,8 @@ type ConfigJSON struct {
 		IsMETexpress     bool   `json:"is_met_express"`
 		IsProduction     bool   `json:"is_production"`
 		EnvironmentLabel string `json:"environment_label"`
+		DisplayAlert     bool   `json:"display_alert"`
+		AlertMessage     string `json:"alert_message"`
 	} `json:"config"`
 	Groups []struct {
 		Name string `json:"name"`

--- a/home/main.go
+++ b/home/main.go
@@ -15,7 +15,6 @@ type ConfigJSON struct {
 		IsMETexpress     bool   `json:"is_met_express"`
 		IsProduction     bool   `json:"is_production"`
 		EnvironmentLabel string `json:"environment_label"`
-		DisplayAlert     bool   `json:"display_alert"`
 		AlertMessage     string `json:"alert_message"`
 	} `json:"config"`
 	Groups []struct {

--- a/home/templates/alert.html
+++ b/home/templates/alert.html
@@ -2,6 +2,8 @@
 
 <div class="container-fluid p-3" style="background-color: #dddddd">
   <div class="alert alert-danger" role="alert">
-    <p>{{ .Config.AlertMessage }}</p>
+    <!-- <p>{{ .Config.AlertMessage }}</p> -->
+    <!-- Regrettably, <blink> is no longer available, so we'll have to settle for marquee -->
+    <marquee>{{ .Config.AlertMessage }}</marquee>
   </div>
 </div>

--- a/home/templates/alert.html
+++ b/home/templates/alert.html
@@ -3,7 +3,7 @@
 <div class="container-fluid p-3" style="background-color: #dddddd">
   <div class="alert alert-danger" role="alert">
     <!-- <p>{{ .Config.AlertMessage }}</p> -->
-    <!-- Regrettably, <blink> is no longer available, so we'll have to settle for marquee -->
+    <!-- When congress hands out shutdown lemons, sometimes you need to make shutdown lemonade :-) -->
     <marquee>{{ .Config.AlertMessage }}</marquee>
   </div>
 </div>

--- a/home/templates/alert.html
+++ b/home/templates/alert.html
@@ -1,0 +1,7 @@
+<!-- Mostly used to convey government shutdowns -->
+
+<div class="container-fluid p-3" style="background-color: #dddddd">
+  <div class="alert alert-danger" role="alert">
+    <p>{{ .Config.AlertMessage }}</p>
+  </div>
+</div>

--- a/home/templates/index.html
+++ b/home/templates/index.html
@@ -13,7 +13,7 @@
     <div id="main" class="container-fluid">
       {{ template "navbar.html" . }}
 
-      {{ if .Config.DisplayAlert }}
+      {{ if .Config.AlertMessage }}
         {{ template "alert.html" . }}
       {{ end }}
 

--- a/home/templates/index.html
+++ b/home/templates/index.html
@@ -13,6 +13,10 @@
     <div id="main" class="container-fluid">
       {{ template "navbar.html" . }}
 
+      {{ if .Config.DisplayAlert }}
+        {{ template "alert.html" . }}
+      {{ end }}
+
       {{ if .Config.IsMETexpress }}
       {{ else }}
         {{ template "toggles.html" . }}


### PR DESCRIPTION
Add the ability to display a bootstrap 5 alert to convey shutdown information to users. The alert visibility and message are controlled via the config file.