### PR TITLE
Deploy MATS to EKS

### DIFF
--- a/kubernetes/overlays/aws-dev/cb-metar/deployment.yaml
+++ b/kubernetes/overlays/aws-dev/cb-metar/deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cb-metar
+spec:
+  template:
+    spec:
+      containers:
+        - name: cb-metar
+          # FIXME: disable resource limits while we do performance tuning
+          # resources:
+          #   requests:
+          #     memory: "1Gi"
+          #     cpu: "0.25"
+          #   limits:
+          #     memory: "8Gi"
+          #     cpu: "4"
+          envFrom:
+            - secretRef:
+                name: cb-metar-secret
+          volumeMounts:
+            - name: cb-metar-settings-file
+              mountPath: /usr/app/settings/cb-metar/settings.json
+              subPath: settings.json
+              readOnly: true
+          imagePullPolicy: Always  # Since we track a long-lived tag
+      imagePullSecrets:
+        - name: mats-ghcr
+      volumes:
+        - name: cb-metar-settings-file
+          configMap:
+            name: cb-metar-config

--- a/kubernetes/overlays/aws-dev/cb-metar/kustomization.yaml
+++ b/kubernetes/overlays/aws-dev/cb-metar/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - ../../../base/cb-metar
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: ghcr.io/noaa-gsl/mats/development/cb-metar
+    newTag: development 
+
+configMapGenerator:
+  - name: cb-metar-config
+    files:
+      - settings.json # Should mirror the appropriate settings.json file in mats-settings
+
+secretGenerator:
+  - name: cb-metar-secret
+    envs:
+      - .env # Should contain mongo_url, root_url, and delay

--- a/kubernetes/overlays/aws-dev/home/deployment.yaml
+++ b/kubernetes/overlays/aws-dev/home/deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: home
+spec:
+  template:
+    spec:
+      containers:
+        - name: home
+          # FIXME: disable resource limits while we do performance tuning
+          # resources:
+          #   requests:
+          #     memory: "1Gi"
+          #     cpu: "0.25"
+          #   limits:
+          #     memory: "8Gi"
+          #     cpu: "4"
+          volumeMounts:
+            - name: home-settings-file
+              mountPath: /app/settings.json
+              subPath: settings.json
+              readOnly: true
+          imagePullPolicy: Always  # Since we track a long-lived tag
+      imagePullSecrets:
+        - name: mats-ghcr
+      volumes:
+        - name: home-settings-file
+          configMap:
+            name: home-config

--- a/kubernetes/overlays/aws-dev/home/kustomization.yaml
+++ b/kubernetes/overlays/aws-dev/home/kustomization.yaml
@@ -1,0 +1,14 @@
+resources:
+  - ../../../base/home
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: ghcr.io/noaa-gsl/mats/development/home
+    newTag: development
+
+configMapGenerator:
+  - name: home-config
+    files:
+      - settings.json # Should mirror the appropriate settings.json file in mats-settings

--- a/kubernetes/overlays/aws-dev/ingress-apps.yaml
+++ b/kubernetes/overlays/aws-dev/ingress-apps.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    # Omit the rewrite-target annotation as it causes problems with Meteor's ROOT_URL
+    nginx.ingress.kubernetes.io/use-regex: "true"
+  name: mats-apps
+  # namespace: mats-dev
+spec:
+  ingressClassName: nginx
+  rules:
+    -  http:
+        paths:
+          - path: /mats-dev/cb-metar
+            pathType: Prefix
+            backend:
+              service:
+                name: cb-metar
+                port:
+                  number: 80

--- a/kubernetes/overlays/aws-dev/ingress-home.yaml
+++ b/kubernetes/overlays/aws-dev/ingress-home.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    # Use nginx's rewrite-target to strip the path prefix before sending the request to the home service
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+  name: mats-home
+  # namespace: mats-dev
+spec:
+  ingressClassName: nginx
+  rules:
+    - http:
+        paths:
+          # Note - this rewrite rule can cause issues if the "path" with the regex capture group
+          # for the nginx rewrite-target gets longer than the paths in ingress-mats.yaml.
+          # This has happened before with the rule for `/mats-dev/ptype`. If multiple paths match,
+          # Kubernetes will prefer the longer path.
+          - path: /mats-dev/(.*)
+            pathType: Prefix
+            backend:
+              service:
+                name: home
+                port:
+                  number: 80

--- a/kubernetes/overlays/aws-dev/kustomization.yaml
+++ b/kubernetes/overlays/aws-dev/kustomization.yaml
@@ -1,0 +1,8 @@
+resources:
+  - cb-metar
+  - home
+  - mongo
+  - ingress-apps.yaml
+  - ingress-home.yaml
+commonLabels:
+  environment: dev

--- a/kubernetes/overlays/aws-dev/mongo/delete-pvc.yaml
+++ b/kubernetes/overlays/aws-dev/mongo/delete-pvc.yaml
@@ -1,0 +1,6 @@
+$patch: delete
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mongo-pv-claim
+

--- a/kubernetes/overlays/aws-dev/mongo/deployment.yaml
+++ b/kubernetes/overlays/aws-dev/mongo/deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mongodb
+spec:
+  template:
+    spec:
+      containers:
+        - name: mongodb
+          # FIXME: disable resource limits while we do performance tuning
+          # resources:
+          #   requests:
+          #     memory: "2Gi"
+          #     cpu: "1"
+          #   limits:
+          #     memory: "2Gi"
+          #     cpu: "1"
+          envFrom:
+            - secretRef:
+                name: mongo-secret
+          volumeMounts:
+            - name: mongo-config-file
+              mountPath: /etc/mongod.conf
+              readOnly: true
+            # FIXME: Switch to an in-memory store until we have a CSI driver
+            - name: mongo-ephemeral-storage
+              mountPath: /data/db
+            - $patch: delete
+              name: mongo-persistent-storage
+      volumes:
+        - name: mongo-config-file
+          configMap:
+            name: mongo-config
+        # FIXME: Switch to an in-memory store until we have a CSI driver
+        - $patch: delete
+          name: mongo-persistent-storage
+        - name: mongo-ephemeral-storage
+          emptyDir:
+            sizeLimit: "2Gi"

--- a/kubernetes/overlays/aws-dev/mongo/kustomization.yaml
+++ b/kubernetes/overlays/aws-dev/mongo/kustomization.yaml
@@ -1,0 +1,22 @@
+resources:
+  - ../../../base/mongo
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+patches:
+  # FIXME: We want to use an in-memory store until we have a CSI driver
+  - path: delete-pvc.yaml
+    target:
+      kind: PersistentVolumeClaim
+      name: mongo-pv-claim
+
+configMapGenerator:
+  - name: mongo-config
+    files:
+      - mongod.conf
+
+secretGenerator:
+  - name: mongo-secret
+    envs:
+    - .env.mongo.secret # Should contain user and password

--- a/kubernetes/overlays/aws-dev/mongo/mongod.conf
+++ b/kubernetes/overlays/aws-dev/mongo/mongod.conf
@@ -1,0 +1,14 @@
+systemLog:
+   destination: file
+   path: "/var/log/mongodb/mongod.log"
+   logAppend: true
+storage:
+   journal:
+      enabled: true
+processManagement:
+   fork: true
+net:
+   bindIp: 127.0.0.1
+   port: 27017
+setParameter:
+   enableLocalhostAuthBypass: false

--- a/kubernetes/overlays/gsl-dev/ingress-apps.yaml
+++ b/kubernetes/overlays/gsl-dev/ingress-apps.yaml
@@ -18,14 +18,14 @@ spec:
                 name: scorecard
                 port:
                   name: http
-          - path: /mats-dev/cb-metar
+          - path: /mats-dev/on-prem/cb-metar
             pathType: Prefix
             backend:
               service:
                 name: cb-metar
                 port:
                   number: 80
-          - path: /mats-dev/cb-metar-capella
+          - path: /mats-dev/capella/cb-metar
             pathType: Prefix
             backend:
               service:


### PR DESCRIPTION
This change:
- updates the gsl-dev cluster manifests to match the URLs actually in use
- adds the initial Kustomize overlays to deploy cb-metar to an EKS cluster

I ended up needing to disable the PVC for mongo in EKS as we don't yet have a CSI driver in the cluster. I also disabled resource requests & limits for all our deployments so that we could do some performance testing/tuning.