### PR TITLE
Fixed upperair level interpolation bug

### DIFF
--- a/apps/upperair/server/dataFunctions/data_dailymodelcycle.js
+++ b/apps/upperair/server/dataFunctions/data_dailymodelcycle.js
@@ -149,13 +149,13 @@ dataDailyModelCycle = function (plotParams, plotFunction) {
         );
       }
       siteDateClause = `and unix_timestamp(o.date)+3600*o.hour >= ${fromSecs} - 1800 and unix_timestamp(o.date)+3600*o.hour <= ${toSecs} + 1800`;
-      levelClause = `and ceil((m0.press-20)/50)*50 >= ${top} and ceil((m0.press-20)/50)*50 <= ${bottom}`;
-      siteLevelClause = `and ceil((o.press-20)/50)*50 >= ${top} and ceil((o.press-20)/50)*50 <= ${bottom}`;
+      levelClause = `and ceil((m0.press-25)/50)*50 >= ${top} and ceil((m0.press-25)/50)*50 <= ${bottom}`;
+      siteLevelClause = `and ceil((o.press-25)/50)*50 >= ${top} and ceil((o.press-25)/50)*50 <= ${bottom}`;
       siteMatchClause =
         "and m0.wmoid = o.wmoid and m0.date = o.date and m0.hour = o.hour and m0.press = o.press";
       NAggregate = "count";
       NClause = "1";
-      levelVar = "ceil((m0.press-20)/50)*50";
+      levelVar = "ceil((m0.press-25)/50)*50";
 
       // remove table prefixes
       const modelComponents = model.split("_");

--- a/apps/upperair/server/dataFunctions/data_dieoff.js
+++ b/apps/upperair/server/dataFunctions/data_dieoff.js
@@ -153,13 +153,13 @@ dataDieoff = function (plotParams, plotFunction) {
         );
       }
       siteDateClause = `and unix_timestamp(o.date)+3600*o.hour >= ${fromSecs} - 1800 and unix_timestamp(o.date)+3600*o.hour <= ${toSecs} + 1800`;
-      levelClause = `and ceil((m0.press-20)/50)*50 >= ${top} and ceil((m0.press-20)/50)*50 <= ${bottom}`;
-      siteLevelClause = `and ceil((o.press-20)/50)*50 >= ${top} and ceil((o.press-20)/50)*50 <= ${bottom}`;
+      levelClause = `and ceil((m0.press-25)/50)*50 >= ${top} and ceil((m0.press-25)/50)*50 <= ${bottom}`;
+      siteLevelClause = `and ceil((o.press-25)/50)*50 >= ${top} and ceil((o.press-25)/50)*50 <= ${bottom}`;
       siteMatchClause =
         "and m0.wmoid = o.wmoid and m0.date = o.date and m0.hour = o.hour and m0.press = o.press";
       NAggregate = "count";
       NClause = "1";
-      levelVar = "ceil((m0.press-20)/50)*50";
+      levelVar = "ceil((m0.press-25)/50)*50";
 
       // remove table prefixes
       const modelComponents = model.split("_");

--- a/apps/upperair/server/dataFunctions/data_histogram.js
+++ b/apps/upperair/server/dataFunctions/data_histogram.js
@@ -148,13 +148,13 @@ dataHistogram = function (plotParams, plotFunction) {
         );
       }
       siteDateClause = `and unix_timestamp(o.date)+3600*o.hour >= ${fromSecs} - 1800 and unix_timestamp(o.date)+3600*o.hour <= ${toSecs} + 1800`;
-      levelClause = `and ceil((m0.press-20)/50)*50 >= ${top} and ceil((m0.press-20)/50)*50 <= ${bottom}`;
-      siteLevelClause = `and ceil((o.press-20)/50)*50 >= ${top} and ceil((o.press-20)/50)*50 <= ${bottom}`;
+      levelClause = `and ceil((m0.press-25)/50)*50 >= ${top} and ceil((m0.press-25)/50)*50 <= ${bottom}`;
+      siteLevelClause = `and ceil((o.press-25)/50)*50 >= ${top} and ceil((o.press-25)/50)*50 <= ${bottom}`;
       siteMatchClause =
         "and m0.wmoid = o.wmoid and m0.date = o.date and m0.hour = o.hour and m0.press = o.press";
       NAggregate = "count";
       NClause = "1";
-      levelVar = "ceil((m0.press-20)/50)*50";
+      levelVar = "ceil((m0.press-25)/50)*50";
 
       // remove table prefixes
       const modelComponents = model.split("_");

--- a/apps/upperair/server/dataFunctions/data_map.js
+++ b/apps/upperair/server/dataFunctions/data_map.js
@@ -72,7 +72,7 @@ dataMap = function (plotParams, plotFunction) {
   const statisticSelect = curve.statistic;
   const statisticClause =
     `sum(${variable[0]}) as square_diff_sum, count(${variable[1]}) as N_sum, sum(${variable[2]}) as obs_model_diff_sum, sum(${variable[3]}) as model_sum, sum(${variable[4]}) as obs_sum, sum(${variable[5]}) as abs_sum, ` +
-    `group_concat(unix_timestamp(m0.date)+3600*m0.hour, ';', ceil((m0.press-20)/50)*50, ';', ${variable[0]}, ';', 1, ';', ${variable[2]}, ';', ${variable[3]}, ';', ${variable[4]}, ';', ${variable[5]} order by unix_timestamp(m0.date)+3600*m0.hour, ceil((m0.press-20)/50)*50) as sub_data, count(${variable[0]}) as N0`;
+    `group_concat(unix_timestamp(m0.date)+3600*m0.hour, ';', ceil((m0.press-25)/50)*50, ';', ${variable[0]}, ';', 1, ';', ${variable[2]}, ';', ${variable[3]}, ';', ${variable[4]}, ';', ${variable[5]} order by unix_timestamp(m0.date)+3600*m0.hour, ceil((m0.press-25)/50)*50) as sub_data, count(${variable[0]}) as N0`;
 
   const { top } = curve;
   const { bottom } = curve;
@@ -87,8 +87,8 @@ dataMap = function (plotParams, plotFunction) {
 
   const dateClause = `and unix_timestamp(m0.date)+3600*m0.hour >= ${fromSecs} - 1800 and unix_timestamp(m0.date)+3600*m0.hour <= ${toSecs} + 1800`;
   const siteDateClause = `and unix_timestamp(o.date)+3600*o.hour >= ${fromSecs} - 1800 and unix_timestamp(o.date)+3600*o.hour <= ${toSecs} + 1800`;
-  const levelClause = `and ceil((m0.press-20)/50)*50 >= ${top} and ceil((m0.press-20)/50)*50 <= ${bottom}`;
-  const siteLevelClause = `and ceil((o.press-20)/50)*50 >= ${top} and ceil((o.press-20)/50)*50 <= ${bottom}`;
+  const levelClause = `and ceil((m0.press-25)/50)*50 >= ${top} and ceil((m0.press-25)/50)*50 <= ${bottom}`;
+  const siteLevelClause = `and ceil((o.press-25)/50)*50 >= ${top} and ceil((o.press-25)/50)*50 <= ${bottom}`;
   const siteMatchClause =
     "and m0.wmoid = o.wmoid and m0.date = o.date and m0.hour = o.hour and m0.press = o.press";
 

--- a/apps/upperair/server/dataFunctions/data_profile.js
+++ b/apps/upperair/server/dataFunctions/data_profile.js
@@ -146,13 +146,13 @@ dataProfile = function (plotParams, plotFunction) {
         );
       }
       siteDateClause = `and unix_timestamp(o.date)+3600*o.hour >= ${fromSecs} - 1800 and unix_timestamp(o.date)+3600*o.hour <= ${toSecs} + 1800`;
-      levelClause = `and ceil((m0.press-20)/50)*50 >= ${top} and ceil((m0.press-20)/50)*50 <= ${bottom}`;
-      siteLevelClause = `and ceil((o.press-20)/50)*50 >= ${top} and ceil((o.press-20)/50)*50 <= ${bottom}`;
+      levelClause = `and ceil((m0.press-25)/50)*50 >= ${top} and ceil((m0.press-25)/50)*50 <= ${bottom}`;
+      siteLevelClause = `and ceil((o.press-25)/50)*50 >= ${top} and ceil((o.press-25)/50)*50 <= ${bottom}`;
       siteMatchClause =
         "and m0.wmoid = o.wmoid and m0.date = o.date and m0.hour = o.hour and m0.press = o.press";
       NAggregate = "count";
       NClause = "1";
-      levelVar = "ceil((m0.press-20)/50)*50";
+      levelVar = "ceil((m0.press-25)/50)*50";
 
       // remove table prefixes
       const modelComponents = model.split("_");

--- a/apps/upperair/server/dataFunctions/data_series.js
+++ b/apps/upperair/server/dataFunctions/data_series.js
@@ -154,13 +154,13 @@ dataSeries = function (plotParams, plotFunction) {
         );
       }
       siteDateClause = `and unix_timestamp(o.date)+3600*o.hour >= ${fromSecs} - 1800 and unix_timestamp(o.date)+3600*o.hour <= ${toSecs} + 1800`;
-      levelClause = `and ceil((m0.press-20)/50)*50 >= ${top} and ceil((m0.press-20)/50)*50 <= ${bottom}`;
-      siteLevelClause = `and ceil((o.press-20)/50)*50 >= ${top} and ceil((o.press-20)/50)*50 <= ${bottom}`;
+      levelClause = `and ceil((m0.press-25)/50)*50 >= ${top} and ceil((m0.press-25)/50)*50 <= ${bottom}`;
+      siteLevelClause = `and ceil((o.press-25)/50)*50 >= ${top} and ceil((o.press-25)/50)*50 <= ${bottom}`;
       siteMatchClause =
         "and m0.wmoid = o.wmoid and m0.date = o.date and m0.hour = o.hour and m0.press = o.press";
       NAggregate = "count";
       NClause = "1";
-      levelVar = "ceil((m0.press-20)/50)*50";
+      levelVar = "ceil((m0.press-25)/50)*50";
 
       // remove table prefixes
       const modelComponents = model.split("_");

--- a/apps/upperair/server/dataFunctions/data_validtime.js
+++ b/apps/upperair/server/dataFunctions/data_validtime.js
@@ -141,13 +141,13 @@ dataValidTime = function (plotParams, plotFunction) {
         );
       }
       siteDateClause = `and unix_timestamp(o.date)+3600*o.hour >= ${fromSecs} - 1800 and unix_timestamp(o.date)+3600*o.hour <= ${toSecs} + 1800`;
-      levelClause = `and ceil((m0.press-20)/50)*50 >= ${top} and ceil((m0.press-20)/50)*50 <= ${bottom}`;
-      siteLevelClause = `and ceil((o.press-20)/50)*50 >= ${top} and ceil((o.press-20)/50)*50 <= ${bottom}`;
+      levelClause = `and ceil((m0.press-25)/50)*50 >= ${top} and ceil((m0.press-25)/50)*50 <= ${bottom}`;
+      siteLevelClause = `and ceil((o.press-25)/50)*50 >= ${top} and ceil((o.press-25)/50)*50 <= ${bottom}`;
       siteMatchClause =
         "and m0.wmoid = o.wmoid and m0.date = o.date and m0.hour = o.hour and m0.press = o.press";
       NAggregate = "count";
       NClause = "1";
-      levelVar = "ceil((m0.press-20)/50)*50";
+      levelVar = "ceil((m0.press-25)/50)*50";
 
       // remove table prefixes
       const modelComponents = model.split("_");


### PR DESCRIPTION
Our upper air app was trying to interpolate levels with `ceil((m0.press-20)/50)*50` instead of `ceil((m0.press-25)/50)*50`, which would have caused our levels on the graph to be slightly off.