### PR TITLE
Don't join main GSL models with other tables

### DIFF
--- a/apps/upperair/server/dataFunctions/data_contour.js
+++ b/apps/upperair/server/dataFunctions/data_contour.js
@@ -144,7 +144,11 @@ dataContour = function (plotParams, plotFunction) {
     // Most of the RAOBs tables don't store a model sum or an obs sum for some reason.
     // So, we get the obs sum from HRRR_OPS, HRRR_HI, or GFS, because the obs are the same across all models.
     // Then we get the model sum by adding the obs sum to the bias sum (bias = model-obs).
-    if (["5", "14", "15", "16", "17", "18"].includes(region.toString())) {
+    // We exclude GSL's main models, which do have all the sums.
+    const modelsToExclude = ["ncep_oper_Areg", "RAP_130_Areg", "RAP_Areg", "HRRR_Areg"];
+    if (modelsToExclude.includes(model)) {
+      queryTableClause = `${queryTableClause}, ${databaseRef.sumsDB}.${model}${region} as m1`;
+    } else if (["5", "14", "15", "16", "17", "18"].includes(region.toString())) {
       queryTableClause = `${queryTableClause}, ${databaseRef.sumsDB}.HRRR_OPS_Areg${region} as m1`;
     } else if (region.toString() === "19") {
       queryTableClause = `${queryTableClause}, ${databaseRef.sumsDB}.HRRR_HI_Areg${region} as m1`;

--- a/apps/upperair/server/dataFunctions/data_contour_diff.js
+++ b/apps/upperair/server/dataFunctions/data_contour_diff.js
@@ -152,7 +152,16 @@ dataContourDiff = function (plotParams, plotFunction) {
       // Most of the RAOBs tables don't store a model sum or an obs sum for some reason.
       // So, we get the obs sum from HRRR_OPS, HRRR_HI, or GFS, because the obs are the same across all models.
       // Then we get the model sum by adding the obs sum to the bias sum (bias = model-obs).
-      if (["5", "14", "15", "16", "17", "18"].includes(region.toString())) {
+      // We exclude GSL's main models, which do have all the sums.
+      const modelsToExclude = [
+        "ncep_oper_Areg",
+        "RAP_130_Areg",
+        "RAP_Areg",
+        "HRRR_Areg",
+      ];
+      if (modelsToExclude.includes(model)) {
+        queryTableClause = `${queryTableClause}, ${databaseRef.sumsDB}.${model}${region} as m1`;
+      } else if (["5", "14", "15", "16", "17", "18"].includes(region.toString())) {
         queryTableClause = `${queryTableClause}, ${databaseRef.sumsDB}.HRRR_OPS_Areg${region} as m1`;
       } else if (region.toString() === "19") {
         queryTableClause = `${queryTableClause}, ${databaseRef.sumsDB}.HRRR_HI_Areg${region} as m1`;

--- a/apps/upperair/server/dataFunctions/data_dailymodelcycle.js
+++ b/apps/upperair/server/dataFunctions/data_dailymodelcycle.js
@@ -132,7 +132,16 @@ dataDailyModelCycle = function (plotParams, plotFunction) {
         // Most of the RAOBs tables don't store a model sum or an obs sum for some reason.
         // So, we get the obs sum from HRRR_OPS, HRRR_HI, or GFS, because the obs are the same across all models.
         // Then we get the model sum by adding the obs sum to the bias sum (bias = model-obs).
-        if (["5", "14", "15", "16", "17", "18"].includes(region.toString())) {
+        // We exclude GSL's main models, which do have all the sums.
+        const modelsToExclude = [
+          "ncep_oper_Areg",
+          "RAP_130_Areg",
+          "RAP_Areg",
+          "HRRR_Areg",
+        ];
+        if (modelsToExclude.includes(model)) {
+          queryTableClause = `${queryTableClause}, ${databaseRef.sumsDB}.${model}${region} as m1`;
+        } else if (["5", "14", "15", "16", "17", "18"].includes(region.toString())) {
           queryTableClause = `${queryTableClause}, ${databaseRef.sumsDB}.HRRR_OPS_Areg${region} as m1`;
         } else if (region.toString() === "19") {
           queryTableClause = `${queryTableClause}, ${databaseRef.sumsDB}.HRRR_HI_Areg${region} as m1`;

--- a/apps/upperair/server/dataFunctions/data_dieoff.js
+++ b/apps/upperair/server/dataFunctions/data_dieoff.js
@@ -136,7 +136,16 @@ dataDieoff = function (plotParams, plotFunction) {
         // Most of the RAOBs tables don't store a model sum or an obs sum for some reason.
         // So, we get the obs sum from HRRR_OPS, HRRR_HI, or GFS, because the obs are the same across all models.
         // Then we get the model sum by adding the obs sum to the bias sum (bias = model-obs).
-        if (["5", "14", "15", "16", "17", "18"].includes(region.toString())) {
+        // We exclude GSL's main models, which do have all the sums.
+        const modelsToExclude = [
+          "ncep_oper_Areg",
+          "RAP_130_Areg",
+          "RAP_Areg",
+          "HRRR_Areg",
+        ];
+        if (modelsToExclude.includes(model)) {
+          queryTableClause = `${queryTableClause}, ${databaseRef.sumsDB}.${model}${region} as m1`;
+        } else if (["5", "14", "15", "16", "17", "18"].includes(region.toString())) {
           queryTableClause = `${queryTableClause}, ${databaseRef.sumsDB}.HRRR_OPS_Areg${region} as m1`;
         } else if (region.toString() === "19") {
           queryTableClause = `${queryTableClause}, ${databaseRef.sumsDB}.HRRR_HI_Areg${region} as m1`;

--- a/apps/upperair/server/dataFunctions/data_histogram.js
+++ b/apps/upperair/server/dataFunctions/data_histogram.js
@@ -131,7 +131,16 @@ dataHistogram = function (plotParams, plotFunction) {
         // Most of the RAOBs tables don't store a model sum or an obs sum for some reason.
         // So, we get the obs sum from HRRR_OPS, HRRR_HI, or GFS, because the obs are the same across all models.
         // Then we get the model sum by adding the obs sum to the bias sum (bias = model-obs).
-        if (["5", "14", "15", "16", "17", "18"].includes(region.toString())) {
+        // We exclude GSL's main models, which do have all the sums.
+        const modelsToExclude = [
+          "ncep_oper_Areg",
+          "RAP_130_Areg",
+          "RAP_Areg",
+          "HRRR_Areg",
+        ];
+        if (modelsToExclude.includes(model)) {
+          queryTableClause = `${queryTableClause}, ${databaseRef.sumsDB}.${model}${region} as m1`;
+        } else if (["5", "14", "15", "16", "17", "18"].includes(region.toString())) {
           queryTableClause = `${queryTableClause}, ${databaseRef.sumsDB}.HRRR_OPS_Areg${region} as m1`;
         } else if (region.toString() === "19") {
           queryTableClause = `${queryTableClause}, ${databaseRef.sumsDB}.HRRR_HI_Areg${region} as m1`;

--- a/apps/upperair/server/dataFunctions/data_profile.js
+++ b/apps/upperair/server/dataFunctions/data_profile.js
@@ -129,7 +129,16 @@ dataProfile = function (plotParams, plotFunction) {
         // Most of the RAOBs tables don't store a model sum or an obs sum for some reason.
         // So, we get the obs sum from HRRR_OPS, HRRR_HI, or GFS, because the obs are the same across all models.
         // Then we get the model sum by adding the obs sum to the bias sum (bias = model-obs).
-        if (["5", "14", "15", "16", "17", "18"].includes(region.toString())) {
+        // We exclude GSL's main models, which do have all the sums.
+        const modelsToExclude = [
+          "ncep_oper_Areg",
+          "RAP_130_Areg",
+          "RAP_Areg",
+          "HRRR_Areg",
+        ];
+        if (modelsToExclude.includes(model)) {
+          queryTableClause = `${queryTableClause}, ${databaseRef.sumsDB}.${model}${region} as m1`;
+        } else if (["5", "14", "15", "16", "17", "18"].includes(region.toString())) {
           queryTableClause = `${queryTableClause}, ${databaseRef.sumsDB}.HRRR_OPS_Areg${region} as m1`;
         } else if (region.toString() === "19") {
           queryTableClause = `${queryTableClause}, ${databaseRef.sumsDB}.HRRR_HI_Areg${region} as m1`;

--- a/apps/upperair/server/dataFunctions/data_series.js
+++ b/apps/upperair/server/dataFunctions/data_series.js
@@ -137,7 +137,16 @@ dataSeries = function (plotParams, plotFunction) {
         // Most of the RAOBs tables don't store a model sum or an obs sum for some reason.
         // So, we get the obs sum from HRRR_OPS, HRRR_HI, or GFS, because the obs are the same across all models.
         // Then we get the model sum by adding the obs sum to the bias sum (bias = model-obs).
-        if (["5", "14", "15", "16", "17", "18"].includes(region.toString())) {
+        // We exclude GSL's main models, which do have all the sums.
+        const modelsToExclude = [
+          "ncep_oper_Areg",
+          "RAP_130_Areg",
+          "RAP_Areg",
+          "HRRR_Areg",
+        ];
+        if (modelsToExclude.includes(model)) {
+          queryTableClause = `${queryTableClause}, ${databaseRef.sumsDB}.${model}${region} as m1`;
+        } else if (["5", "14", "15", "16", "17", "18"].includes(region.toString())) {
           queryTableClause = `${queryTableClause}, ${databaseRef.sumsDB}.HRRR_OPS_Areg${region} as m1`;
         } else if (region.toString() === "19") {
           queryTableClause = `${queryTableClause}, ${databaseRef.sumsDB}.HRRR_HI_Areg${region} as m1`;

--- a/apps/upperair/server/dataFunctions/data_simple_scatter.js
+++ b/apps/upperair/server/dataFunctions/data_simple_scatter.js
@@ -167,7 +167,16 @@ dataSimpleScatter = function (plotParams, plotFunction) {
       // Most of the RAOBs tables don't store a model sum or an obs sum for some reason.
       // So, we get the obs sum from HRRR_OPS, HRRR_HI, or GFS, because the obs are the same across all models.
       // Then we get the model sum by adding the obs sum to the bias sum (bias = model-obs).
-      if (["5", "14", "15", "16", "17", "18"].includes(region.toString())) {
+      // We exclude GSL's main models, which do have all the sums.
+      const modelsToExclude = [
+        "ncep_oper_Areg",
+        "RAP_130_Areg",
+        "RAP_Areg",
+        "HRRR_Areg",
+      ];
+      if (modelsToExclude.includes(model)) {
+        queryTableClause = `${queryTableClause}, ${databaseRef.sumsDB}.${model}${region} as m1`;
+      } else if (["5", "14", "15", "16", "17", "18"].includes(region.toString())) {
         queryTableClause = `${queryTableClause}, ${databaseRef.sumsDB}.HRRR_OPS_Areg${region} as m1`;
       } else if (region.toString() === "19") {
         queryTableClause = `${queryTableClause}, ${databaseRef.sumsDB}.HRRR_HI_Areg${region} as m1`;

--- a/apps/upperair/server/dataFunctions/data_validtime.js
+++ b/apps/upperair/server/dataFunctions/data_validtime.js
@@ -124,7 +124,16 @@ dataValidTime = function (plotParams, plotFunction) {
         // Most of the RAOBs tables don't store a model sum or an obs sum for some reason.
         // So, we get the obs sum from HRRR_OPS, HRRR_HI, or GFS, because the obs are the same across all models.
         // Then we get the model sum by adding the obs sum to the bias sum (bias = model-obs).
-        if (["5", "14", "15", "16", "17", "18"].includes(region.toString())) {
+        // We exclude GSL's main models, which do have all the sums.
+        const modelsToExclude = [
+          "ncep_oper_Areg",
+          "RAP_130_Areg",
+          "RAP_Areg",
+          "HRRR_Areg",
+        ];
+        if (modelsToExclude.includes(model)) {
+          queryTableClause = `${queryTableClause}, ${databaseRef.sumsDB}.${model}${region} as m1`;
+        } else if (["5", "14", "15", "16", "17", "18"].includes(region.toString())) {
           queryTableClause = `${queryTableClause}, ${databaseRef.sumsDB}.HRRR_OPS_Areg${region} as m1`;
         } else if (region.toString() === "19") {
           queryTableClause = `${queryTableClause}, ${databaseRef.sumsDB}.HRRR_HI_Areg${region} as m1`;


### PR DESCRIPTION
Most of our upper air RAOB tables need to be joined with the GFS or other models to fill in missing obs sums. However, this is unnecessary for the lab's primary models. This PR excludes those models.