### PR TITLE
Update container & CI for Meteor 3

### DIFF
--- a/.github/workflows/build-mats.yml
+++ b/.github/workflows/build-mats.yml
@@ -42,7 +42,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-node@v4
         with:
-          node-version: '14'  # This needs to match the version used by our Meteor release
+          node-version: '22'
       - name: Install dependencies
         working-directory: apps/${{ matrix.app }}
         run: npm ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # This tag here should match the app's Meteor version, per .meteor/release
-FROM geoffreybooth/meteor-base:2.16 AS meteor-builder
+FROM geoffreybooth/meteor-base:3.1.2 AS meteor-builder
 
 ARG APPNAME
 
@@ -20,7 +20,7 @@ RUN bash ${SCRIPTS_FOLDER}/build-meteor-bundle.sh
 
 
 # Use the specific version of Node expected by your Meteor release, per https://docs.meteor.com/changelog.html
-FROM node:14-bullseye-slim AS production
+FROM node:22-bookworm-slim AS production
 
 # Set Build ARGS
 ARG APPNAME

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,14 +32,25 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Install runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    bash \
-    ca-certificates \
-    python3 \
-    python3-pip \
-    && apt-get clean && rm -rf /var/lib/apt/lists/* \
-    && python3 -m pip install --no-cache-dir \
-      numpy \
-      pymysql
+  bash \
+  ca-certificates \
+  python3 \
+  python3-pip \
+  python3-venv \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Create & activate a Python virtual environment
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv ${VIRTUAL_ENV}
+ENV  PATH="${VIRTUAL_ENV}/bin:$PATH"
+
+# Ensure the Python tooling is up-to-date
+RUN python3 -m pip install --upgrade pip setuptools wheel
+
+# Install Python dependencies for MATScomon in the virtual environment
+RUN python3 -m pip install --no-cache-dir \
+  numpy \
+  pymysql
 
 # Set Environment
 ENV APP_FOLDER=/usr/app
@@ -65,11 +76,11 @@ COPY container-scripts/run_app.sh ${APP_FOLDER}/
 
 # The app won't work without a writeable settings dir and local Node fileCache
 RUN mkdir -p ${SETTINGS_DIR} \
-    && chown -R node:node ${APP_FOLDER}/settings \
-    && chmod -R 755 ${APP_FOLDER}/settings \
-    && touch ${APP_BUNDLE_FOLDER}/bundle/programs/server/fileCache \
-    && chown node:node ${APP_BUNDLE_FOLDER}/bundle/programs/server/fileCache \
-    && chmod 644 ${APP_BUNDLE_FOLDER}/bundle/programs/server/fileCache
+  && chown -R node:node ${APP_FOLDER}/settings \
+  && chmod -R 755 ${APP_FOLDER}/settings \
+  && touch ${APP_BUNDLE_FOLDER}/bundle/programs/server/fileCache \
+  && chown node:node ${APP_BUNDLE_FOLDER}/bundle/programs/server/fileCache \
+  && chmod 644 ${APP_BUNDLE_FOLDER}/bundle/programs/server/fileCache
 
 # Install the Meteor app's NPM dependencies
 # g++ & build-essential would be needed for ARM/Apple Silicon builds in order to recompile fibers
@@ -77,8 +88,8 @@ RUN bash $SCRIPTS_FOLDER/build-meteor-npm-dependencies.sh
 
 # Update the OS packages in the container
 RUN apt-get update \
-    && apt-get -y upgrade \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+  && apt-get -y upgrade \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 EXPOSE ${PORT}
 USER node


### PR DESCRIPTION
Updates CI & our container image for Meteor 3. Key changes:

* Update the Docker Meteor image used in the Dockerfile to match the version of Meteor we're updating the code to
* Update various Docker Node images to Node 22
* Install our runtime Python dependencies in a virtual environment