### PR TITLE
Add workarounds to reduce CI flakiness

### DIFF
--- a/.github/workflows/build-home.yml
+++ b/.github/workflows/build-home.yml
@@ -89,14 +89,25 @@ jobs:
             exit 1
             fi
 
-        - name: Build image
-          run: |
-            docker build \
-            --build-arg BUILDVER="${{ env.VERSION }}" \
-            --build-arg COMMITBRANCH=${{ env.BRANCH }} \
-            --build-arg COMMITSHA=${{ github.sha }} \
-            -t ${{ env.DEV_REGISTRY }}/home:${{ env.BRANCH }} \
-            .
+        - name: Login to GitHub Container Registry
+          uses: docker/login-action@v4
+          with:
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+
+        - uses: docker/setup-qemu-action@v4
+        - uses: docker/setup-buildx-action@v4
+        - name: Build image and push
+          uses: docker/build-push-action@v7
+          with:
+            context: .
+            tags: ${{ env.DEV_REGISTRY }}/home:${{ env.BRANCH }}
+            build-args: |
+              BUILDVER=${{ env.VERSION }}
+              COMMITBRANCH=${{ env.BRANCH }}
+              COMMITSHA=${{ github.sha }}
+            push: true
 
         - name: Scan image with Trivy
           uses: aquasecurity/trivy-action@master
@@ -110,13 +121,6 @@ jobs:
           uses: github/codeql-action/upload-sarif@v4
           with:
             sarif_file: 'trivy-results-home.sarif'
-
-        - name: Login to GitHub Container Registry
-          uses: docker/login-action@v4
-          with:
-            registry: ghcr.io
-            username: ${{ github.actor }}
-            password: ${{ secrets.GITHUB_TOKEN }}
 
         - name: Push image to dev registry
           run: |

--- a/.github/workflows/build-home.yml
+++ b/.github/workflows/build-home.yml
@@ -101,7 +101,7 @@ jobs:
         - name: Build image and push
           uses: docker/build-push-action@v7
           with:
-            context: .
+            context: ./home
             tags: ${{ env.DEV_REGISTRY }}/home:${{ env.BRANCH }}
             build-args: |
               BUILDVER=${{ env.VERSION }}

--- a/.github/workflows/build-home.yml
+++ b/.github/workflows/build-home.yml
@@ -121,7 +121,3 @@ jobs:
           uses: github/codeql-action/upload-sarif@v4
           with:
             sarif_file: 'trivy-results-home.sarif'
-
-        - name: Push image to dev registry
-          run: |
-            docker push ${{ env.DEV_REGISTRY }}/home:${{ env.BRANCH }}

--- a/.github/workflows/build-mats.yml
+++ b/.github/workflows/build-mats.yml
@@ -82,7 +82,7 @@ jobs:
           - upperair
     steps:
       - name: Gather Resource Metrics
-        run: |
+        run: | # Temporary workaround to help debug job timeouts (ESOCKETTIMEDOUT errors)
           while true; do
             echo "========== $(date -u) ==========" >> resource-metrics.log
             

--- a/.github/workflows/build-mats.yml
+++ b/.github/workflows/build-mats.yml
@@ -63,7 +63,7 @@ jobs:
       security-events: write
     strategy:
       fail-fast: false # Temporary workaround for job timeouts (ESOCKETTIMEDOUT errors)
-      max-parallel: 5 # Temporary workaround for job timeouts (ESOCKETTIMEDOUT errors)
+      max-parallel: 15 # Temporary workaround for job timeouts (ESOCKETTIMEDOUT errors)
       matrix:
         app: 
           - airQuality
@@ -181,7 +181,7 @@ jobs:
       
       - name: Upload Resource Metrics
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: resource-metrics-${{ matrix.app }}.log
           path: resource-metrics.log

--- a/.github/workflows/build-mats.yml
+++ b/.github/workflows/build-mats.yml
@@ -82,6 +82,29 @@ jobs:
           - surfrad
           - upperair
     steps:
+      - name: Gather Resource Metrics
+        run: |
+          while true; do
+            echo "========== $(date -u) ==========" >> resource-metrics.log
+            
+            echo "--- Memory ---" >> resource-metrics.log
+            free -m >> resource-metrics.log
+            
+            echo "--- CPU & Load ---" >> resource-metrics.log
+            top -b -n 1 -E=m -e=m | head -n 15 >> resource-metrics.log
+            
+            echo "--- Disk I/O ---" >> resource-metrics.log
+            # Print column headers for /proc/diskstats manually for readability
+            echo "Major Minor Name Reads ReadMerges SectorsRead MsReading Writes WriteMerges SectorsWritten MsWriting I/O_InProgress MsIO WeightedMsIO Discards DiscardMerges SectorsDiscarded MsDiscarding Flushing FlushTicks" >> resource-metrics.log
+            # Filter out loop devices (virtual filesystems) to reduce noise
+            cat /proc/diskstats | grep -v 'loop' >> resource-metrics.log
+            
+            echo "--- Network I/O ---" >> resource-metrics.log
+            cat /proc/net/dev | grep -E 'eth0|docker0' >> resource-metrics.log
+            
+            echo "" >> resource-metrics.log
+            sleep 5
+          done &
       - name: Checkout code
         uses: actions/checkout@v6
         with:
@@ -155,3 +178,10 @@ jobs:
       - name: Push image to dev registry
         run: |
             docker push ${{ env.DEV_REGISTRY }}/${{ env.APP_LOWERCASE }}:${{ env.BRANCH }}
+      
+      - name: Upload Resource Metrics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: resource-metrics-${{ matrix.app }}.log
+          path: resource-metrics.log

--- a/.github/workflows/build-mats.yml
+++ b/.github/workflows/build-mats.yml
@@ -164,8 +164,8 @@ jobs:
             BUILDVER=${{ env.VERSION }}
             COMMITBRANCH=${{ github.BRANCH }}
             COMMITSHA=${{ github.sha }}
-          # cache-from: type=gha,scope=${{ github.ref_name }}-${{ matrix.app }} # add each app to GHA cache to avoid redownloading dependencies if they haven't changed
-          # cache-to: type=gha,mode=min,scope=${{ github.ref_name }}-${{ matrix.app }} # add each app to GHA cache to avoid redownloading dependencies if they haven't changed
+          cache-from: type=gha,scope=${{ github.ref_name }}-${{ matrix.app }} # add each app to GHA cache to avoid redownloading dependencies if they haven't changed
+          cache-to: type=gha,mode=min,scope=${{ github.ref_name }}-${{ matrix.app }} # add each app to GHA cache to avoid redownloading dependencies if they haven't changed
           push: true
 
       - name: Scan image with Trivy

--- a/.github/workflows/build-mats.yml
+++ b/.github/workflows/build-mats.yml
@@ -162,7 +162,7 @@ jobs:
           build-args: |
             APPNAME=${{ matrix.app }}
             BUILDVER=${{ env.VERSION }}
-            COMMITBRANCH=${{ github.BRANCH }}
+            COMMITBRANCH=${{ env.BRANCH }}
             COMMITSHA=${{ github.sha }}
           cache-from: type=gha,scope=${{ github.ref_name }}-${{ matrix.app }} # add each app to GHA cache to avoid redownloading dependencies if they haven't changed
           cache-to: type=gha,mode=min,scope=${{ github.ref_name }}-${{ matrix.app }} # add each app to GHA cache to avoid redownloading dependencies if they haven't changed

--- a/.github/workflows/build-mats.yml
+++ b/.github/workflows/build-mats.yml
@@ -62,7 +62,7 @@ jobs:
       packages: write
       security-events: write
     strategy:
-      fail-fast: true
+      fail-fast: false # Temporary workaround for job timeouts (ESOCKETTIMEDOUT errors)
       max-parallel: 5 # Temporary workaround for job timeouts (ESOCKETTIMEDOUT errors)
       matrix:
         app: 

--- a/.github/workflows/build-mats.yml
+++ b/.github/workflows/build-mats.yml
@@ -144,15 +144,29 @@ jobs:
         run: |
           echo "APP_LOWERCASE=${APP,,}" >> $GITHUB_ENV
 
-      - name: Build image
-        run: |
-          docker build \
-            --build-arg APPNAME=${{ matrix.app }} \
-            --build-arg BUILDVER="${{ env.VERSION }}" \
-            --build-arg COMMITBRANCH=${{ env.BRANCH }} \
-            --build-arg COMMITSHA=${{ github.sha }} \
-            -t ${{ env.DEV_REGISTRY }}/${{ env.APP_LOWERCASE }}:${{ env.BRANCH }} \
-            .
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Build image and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          tags: ${{ env.DEV_REGISTRY }}/${{ env.APP_LOWERCASE }}:${{ env.BRANCH }}
+          build-args: |
+            APPNAME=${{ matrix.app }}
+            BUILDVER=${{ env.VERSION }}
+            COMMITBRANCH=${{ github.BRANCH }}
+            COMMITSHA=${{ github.sha }}
+          # cache-from: type=gha,scope=${{ github.ref_name }}-${{ matrix.app }} # add each app to GHA cache to avoid redownloading dependencies if they haven't changed
+          # cache-to: type=gha,mode=min,scope=${{ github.ref_name }}-${{ matrix.app }} # add each app to GHA cache to avoid redownloading dependencies if they haven't changed
+          push: true
 
       - name: Scan image with Trivy
         uses: aquasecurity/trivy-action@master
@@ -167,17 +181,6 @@ jobs:
         with:
           sarif_file: 'trivy-results-${{ env.APP_LOWERCASE }}.sarif'
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Push image to dev registry
-        run: |
-            docker push ${{ env.DEV_REGISTRY }}/${{ env.APP_LOWERCASE }}:${{ env.BRANCH }}
-      
       - name: Upload Resource Metrics
         if: always()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build-mats.yml
+++ b/.github/workflows/build-mats.yml
@@ -63,6 +63,7 @@ jobs:
       security-events: write
     strategy:
       fail-fast: true
+      max-parallel: 5 # Temporary workaround for job timeouts (ESOCKETTIMEDOUT errors)
       matrix:
         app: 
           - airQuality

--- a/.github/workflows/build-mats.yml
+++ b/.github/workflows/build-mats.yml
@@ -63,7 +63,6 @@ jobs:
       security-events: write
     strategy:
       fail-fast: false # Temporary workaround for job timeouts (ESOCKETTIMEDOUT errors)
-      max-parallel: 15 # Temporary workaround for job timeouts (ESOCKETTIMEDOUT errors)
       matrix:
         app: 
           - airQuality


### PR DESCRIPTION
Disable `fail-fast` for the MATS container image build. This will make it easier to recover if we do see `ESOCKETTIMEDOUT` CI errors.

There's also a good chance we're starving the VM of resources during the build. This change added monitoring of the actions runner's resources to keep an eye on resource utilization. From that, I was able to determine that we're seeing a fun combination of network timeouts/CPU maxing out/disk I/O backing up. This is most likely due to rate limiting from the Meteor or NPM package registry, and potentially a disk I/O issue since we're downloading all these packages in a docker build - the `overlayfs` driver does add I/O overhead.

Due to those results, I went ahead and switch MATS & Home app builds to docker's "build-push-action". It uses buildx which is more efficient than the traditional `docker build`.

A permanent solution will most likely be to look into caching the packages we need between builds and/or re-architect how MATS is built so we only need to make a single container image. 

Part of #1391