### PR TITLE
Fix CI image builds

### DIFF
--- a/.github/workflows/build-home.yml
+++ b/.github/workflows/build-home.yml
@@ -108,6 +108,7 @@ jobs:
               COMMITBRANCH=${{ env.BRANCH }}
               COMMITSHA=${{ github.sha }}
             push: true
+            platforms: linux/amd64,linux/arm64
 
         - name: Scan image with Trivy
           uses: aquasecurity/trivy-action@master

--- a/.github/workflows/build-mats.yml
+++ b/.github/workflows/build-mats.yml
@@ -167,6 +167,10 @@ jobs:
           cache-from: type=gha,scope=${{ github.ref_name }}-${{ matrix.app }} # add each app to GHA cache to avoid redownloading dependencies if they haven't changed
           cache-to: type=gha,mode=min,scope=${{ github.ref_name }}-${{ matrix.app }} # add each app to GHA cache to avoid redownloading dependencies if they haven't changed
           push: true
+          # Disable provenance & sbom generation for single-arch builds as
+          # they confuse the docker client and result in "manifest unknown" errors
+          provenance: false
+          sbom: false
 
       - name: Scan image with Trivy
         uses: aquasecurity/trivy-action@master


### PR DESCRIPTION
It looks like GHCR is serving up the attestation/provenance manifest instead of the actual image. Add a multiarch build to the home app, and disable attestations & SBOMs in the MATS single arch images to make the image retrievable by docker pull.

This is most likely a result of switching to buildx & docker build-push-action. (Introduced in #1393) However, it may also be related to docker's switch from Moby to containerd as the storage engine. 