### PR TITLE
Setup sysdig scanning in CI

### DIFF
--- a/.github/workflows/build-home.yml
+++ b/.github/workflows/build-home.yml
@@ -126,8 +126,9 @@ jobs:
             sysdig-secure-url: ${{ vars.SYSDIG_SECURE_ENDPOINT }}
             image-tag: '${{ env.DEV_REGISTRY }}/home:${{ env.BRANCH }}'
             stop-on-failed-policy-eval: false
-            stop-on-processing-error: false
+            stop-on-processing-error: true
             severity-at-least: high
+            group-by-package: true
 
         - name: Upload Sysdig scan results
           if: success() || failure()

--- a/.github/workflows/build-home.yml
+++ b/.github/workflows/build-home.yml
@@ -123,7 +123,7 @@ jobs:
           uses: sysdiglabs/scan-action@v6
           with:
             sysdig-secure-token: ${{ secrets.SYSDIG_SECURE_TOKEN }}
-            sysdig-secure-url: ${{ secrets.SYSDIG_SECURE_ENDPOINT }}
+            sysdig-secure-url: ${{ vars.SYSDIG_SECURE_ENDPOINT }}
             image-tag: '${{ env.DEV_REGISTRY }}/home:${{ env.BRANCH }}'
             stop-on-failed-policy-eval: false
             stop-on-processing-error: false

--- a/.github/workflows/build-home.yml
+++ b/.github/workflows/build-home.yml
@@ -125,7 +125,7 @@ jobs:
             sysdig-secure-token: ${{ secrets.SYSDIG_SECURE_TOKEN }}
             sysdig-secure-url: ${{ vars.SYSDIG_SECURE_ENDPOINT }}
             image-tag: '${{ env.DEV_REGISTRY }}/home:${{ env.BRANCH }}'
-            stop-on-failed-policy-eval: false
+            stop-on-failed-policy-eval: false # TODO - switch to true once we're ready to use sysdig as our primary scanner
             stop-on-processing-error: true
             severity-at-least: high
             group-by-package: true

--- a/.github/workflows/build-home.yml
+++ b/.github/workflows/build-home.yml
@@ -118,6 +118,23 @@ jobs:
             output: 'trivy-results-home.sarif'
             ignore-unfixed: true
 
+        - name: Scan image with Sysdig
+          id: scan
+          uses: sysdiglabs/scan-action@v6
+          with:
+            sysdig-secure-token: ${{ secrets.SYSDIG_SECURE_TOKEN }}
+            sysdig-secure-url: ${{ secrets.SYSDIG_SECURE_ENDPOINT }}
+            image-tag: '${{ env.DEV_REGISTRY }}/home:${{ env.BRANCH }}'
+            stop-on-failed-policy-eval: false
+            stop-on-processing-error: false
+            severity-at-least: high
+
+        - name: Upload Sysdig scan results
+          if: success() || failure()
+          uses: github/codeql-action/upload-sarif@v4
+          with:
+            sarif_file: ${{ github.workspace }}/sarif.json
+
         - name: Upload Trivy scan results to GitHub Security tab
           uses: github/codeql-action/upload-sarif@v4
           with:

--- a/.github/workflows/build-mats.yml
+++ b/.github/workflows/build-mats.yml
@@ -183,6 +183,23 @@ jobs:
         with:
           sarif_file: 'trivy-results-${{ env.APP_LOWERCASE }}.sarif'
 
+      - name: Scan image with Sysdig
+        id: scan
+        uses: sysdiglabs/scan-action@v6
+        with:
+          sysdig-secure-token: ${{ secrets.SYSDIG_SECURE_TOKEN }}
+          sysdig-secure-url: ${{ vars.SYSDIG_SECURE_ENDPOINT }}
+          image-tag: '${{ env.DEV_REGISTRY }}/${{ env.APP_LOWERCASE }}:${{ env.BRANCH }}'
+          stop-on-failed-policy-eval: false
+          stop-on-processing-error: false
+          severity-at-least: high
+
+      - name: Upload Sysdig scan results
+        if: success() || failure()
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: ${{ github.workspace }}/sarif.json
+
       - name: Upload Resource Metrics
         if: always()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build-mats.yml
+++ b/.github/workflows/build-mats.yml
@@ -190,7 +190,7 @@ jobs:
           sysdig-secure-token: ${{ secrets.SYSDIG_SECURE_TOKEN }}
           sysdig-secure-url: ${{ vars.SYSDIG_SECURE_ENDPOINT }}
           image-tag: '${{ env.DEV_REGISTRY }}/${{ env.APP_LOWERCASE }}:${{ env.BRANCH }}'
-          stop-on-failed-policy-eval: false
+          stop-on-failed-policy-eval: false # TODO - switch to true once we're ready to use sysdig as our primary scanner
           stop-on-processing-error: true
           severity-at-least: high
           group-by-package: true

--- a/.github/workflows/build-mats.yml
+++ b/.github/workflows/build-mats.yml
@@ -191,8 +191,9 @@ jobs:
           sysdig-secure-url: ${{ vars.SYSDIG_SECURE_ENDPOINT }}
           image-tag: '${{ env.DEV_REGISTRY }}/${{ env.APP_LOWERCASE }}:${{ env.BRANCH }}'
           stop-on-failed-policy-eval: false
-          stop-on-processing-error: false
+          stop-on-processing-error: true
           severity-at-least: high
+          group-by-package: true
 
       - name: Upload Sysdig scan results
         if: success() || failure()


### PR DESCRIPTION
Setup the Sysdig CI scanner alongside Trivy in the MATS CI pipelines so that we can evaluate it. I set the Sysdig scanner up in "informational" mode - it won't fail CI if the scan fails. If we adopt the scanner going forward, we'll want to change that.